### PR TITLE
Add PR preview to GitHub Pages workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main # Or your default branch
+  pull_request:
   workflow_dispatch: # Allows manual triggering
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -66,3 +67,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          preview: ${{ github.event_name == 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This will start the application, and you can view it in your browser at the loca
 <details>
 <summary><b>Deployment</b></summary>
 
-This project is automatically built and deployed to GitHub Pages on every push to the `main` branch using a GitHub Actions workflow.
+This project is automatically built and deployed to GitHub Pages on every push to the `main` branch using a GitHub Actions workflow. Pull requests trigger the same workflow but deploy to a temporary preview site so changes can be reviewed before merging.
 
 The live site can be accessed at: [https://ba-calderonmorales.github.io/immersive-awe-canvas/](https://ba-calderonmorales.github.io/immersive-awe-canvas/)
 


### PR DESCRIPTION
## Summary
- build and deploy on pull_request events
- deploy preview sites when workflow triggered by a PR
- document preview deployment in README

## Testing
- `bun run lint` *(fails: unexpected any, etc.)*
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6855011856248333bb1f76c144c827e0