### PR TITLE
Add PR preview to GitHub Pages workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,76 @@
+---
+name: Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: pages-preview-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build project
+        run: bun run build
+        env:
+          VITE_DEPLOY_TARGET: 'github'
+          CI: true
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      pull-requests: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Live preview: ${{ steps.deployment.outputs.page_url }}`
+            })

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This will start the application, and you can view it in your browser at the loca
 <details>
 <summary><b>Deployment</b></summary>
 
-This project is automatically built and deployed to GitHub Pages on every push to the `main` branch using a GitHub Actions workflow.
+This project is automatically built and deployed to GitHub Pages on every push to the `main` branch using a GitHub Actions workflow. Pull requests run a separate preview workflow that deploys to a temporary preview site so changes can be reviewed before merging.
 
 The live site can be accessed at: [https://ba-calderonmorales.github.io/immersive-awe-canvas/](https://ba-calderonmorales.github.io/immersive-awe-canvas/)
 


### PR DESCRIPTION
## Summary
- add a preview workflow triggered on pull requests
- revert deployment workflow to only run on push events
- document the separate preview workflow in the README

## Testing
- `bun run lint` *(fails: Unexpected any, etc.)*
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6855011856248333bb1f76c144c827e0