### PR TITLE
Add interactive physics playground world

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@react-three/cannon": "^1.2.0",
         "@react-three/drei": "^9.122.0",
         "@react-three/fiber": "^8.18.0",
         "@react-three/postprocessing": "^2.19.1",
@@ -2625,6 +2626,17 @@
       "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
       "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
       "license": "MIT"
+    },
+    "node_modules/@react-three/cannon": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@react-three/cannon/-/cannon-1.4.0.tgz",
+      "integrity": "sha512-cQsF5Lzjoz0S/gC1hGPeV9uc58TQOf8SO6TOU3YIxfhKFqHWiyjviQ6Q0B+AsMIyiY5mIIEDW64BmRO/j9NkJg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0",
+        "react-dom": ">=17.0",
+        "typescript": ">=4.2"
+      }
     },
     "node_modules/@react-three/drei": {
       "version": "9.122.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@react-three/drei": "^9.122.0",
     "@react-three/fiber": "^8.18.0",
     "@react-three/postprocessing": "^2.19.1",
+    "@react-three/cannon": "^1.2.0",
     "@supabase/supabase-js": "^2.50.0",
     "@tanstack/react-query": "^5.56.2",
     "@vitejs/plugin-react": "^4.5.2",

--- a/src/components/experience/ExperienceLayout.tsx
+++ b/src/components/experience/ExperienceLayout.tsx
@@ -13,6 +13,7 @@ interface ExperienceLayoutProps {
   isSettingsOpen: boolean;
   isMobile: boolean;
   onUpdateSceneConfig: (config: SceneConfig) => void;
+  isGrabMode: boolean;
 }
 
 const ExperienceLayout = ({
@@ -24,16 +25,18 @@ const ExperienceLayout = ({
   isSettingsOpen,
   isMobile,
   onUpdateSceneConfig,
+  isGrabMode,
 }: ExperienceLayoutProps) => {
   if (isMobile) {
     return (
       <div className="w-full h-full">
-        <WorldView 
-          sceneConfig={editableSceneConfig} 
-          isTransitioning={isTransitioning} 
-          worldIndex={currentWorldIndex} 
-          isLocked={isObjectLocked} 
-          onToggleLock={onToggleObjectLock} 
+        <WorldView
+          sceneConfig={editableSceneConfig}
+          isTransitioning={isTransitioning}
+          worldIndex={currentWorldIndex}
+          isLocked={isObjectLocked}
+          onToggleLock={onToggleObjectLock}
+          isGrabMode={isGrabMode}
         />
       </div>
     );
@@ -43,12 +46,13 @@ const ExperienceLayout = ({
     <ResizablePanelGroup direction="horizontal">
       <ResizablePanel>
         <div className="w-full h-full relative">
-          <WorldView 
-            sceneConfig={editableSceneConfig} 
-            isTransitioning={isTransitioning} 
-            worldIndex={currentWorldIndex} 
-            isLocked={isObjectLocked} 
-            onToggleLock={onToggleObjectLock} 
+          <WorldView
+            sceneConfig={editableSceneConfig}
+            isTransitioning={isTransitioning}
+            worldIndex={currentWorldIndex}
+            isLocked={isObjectLocked}
+            onToggleLock={onToggleObjectLock}
+            isGrabMode={isGrabMode}
           />
         </div>
       </ResizablePanel>

--- a/src/components/experience/ExperienceLogic.tsx
+++ b/src/components/experience/ExperienceLogic.tsx
@@ -44,6 +44,8 @@ const ExperienceLogic = () => {
     setIsSettingsOpen,
     isUiHidden,
     setIsUiHidden,
+    isGrabMode,
+    setIsGrabMode,
     showUiHint,
     setShowUiHint,
     hintShownRef,
@@ -121,6 +123,7 @@ const ExperienceLogic = () => {
         isSettingsOpen={isSettingsOpen}
         isMobile={isMobile}
         onUpdateSceneConfig={setEditableSceneConfig}
+        isGrabMode={isGrabMode}
       />
 
       <ExperienceUI
@@ -140,6 +143,8 @@ const ExperienceLogic = () => {
         onToggleSettings={setIsSettingsOpen}
         isUiHidden={isUiHidden}
         onToggleUiHidden={() => setIsUiHidden((h) => !h)}
+        isGrabMode={isGrabMode}
+        onToggleGrabMode={() => setIsGrabMode((g) => !g)}
         showUiHint={showUiHint}
       />
 

--- a/src/components/experience/ExperienceUI.tsx
+++ b/src/components/experience/ExperienceUI.tsx
@@ -25,6 +25,8 @@ interface ExperienceUIProps {
   onToggleSettings: (isOpen: boolean) => void;
   isUiHidden: boolean;
   onToggleUiHidden: () => void;
+  isGrabMode: boolean;
+  onToggleGrabMode: () => void;
   showUiHint?: boolean;
 }
 
@@ -45,6 +47,8 @@ const ExperienceUI = ({
   onToggleSettings,
   isUiHidden,
   onToggleUiHidden,
+  isGrabMode,
+  onToggleGrabMode,
   showUiHint = false,
 }: ExperienceUIProps) => {
   const isMobile = useIsMobile();
@@ -77,11 +81,13 @@ const ExperienceUI = ({
   if (isUiHidden) {
     return (
       <TooltipProvider>
-        <HiddenUiView 
+        <HiddenUiView
           onToggleUiHidden={onToggleUiHidden}
           showUiHint={showUiHint}
           uiColor={uiColor}
           theme={theme}
+          onToggleGrabMode={onToggleGrabMode}
+          isGrabMode={isGrabMode}
         />
       </TooltipProvider>
     );

--- a/src/components/experience/WorldView.tsx
+++ b/src/components/experience/WorldView.tsx
@@ -10,9 +10,10 @@ interface WorldViewProps {
   worldIndex: number;
   isLocked: boolean;
   onToggleLock: () => void;
+  isGrabMode: boolean;
 }
 
-const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggleLock }: WorldViewProps) => {
+const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggleLock, isGrabMode }: WorldViewProps) => {
   return (
     <div
       key={worldIndex}
@@ -20,7 +21,7 @@ const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggl
     >
       <WorldContainer onToggleLock={onToggleLock} isLocked={isLocked}>
         <KeyboardControls />
-        <DynamicWorld sceneConfig={sceneConfig} isLocked={isLocked} />
+        <DynamicWorld sceneConfig={sceneConfig} isLocked={isLocked} isGrabMode={isGrabMode} />
       </WorldContainer>
     </div>
   );

--- a/src/components/experience/ui/HiddenUiView.tsx
+++ b/src/components/experience/ui/HiddenUiView.tsx
@@ -1,7 +1,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Eye, ChevronDown, ChevronUp, Pointer, Info } from "lucide-react";
+import { Eye, ChevronDown, ChevronUp, Pointer, Info, Hand } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useKeyboardShortcuts } from "@/context/KeyboardShortcutsContext";
@@ -11,9 +11,11 @@ interface HiddenUiViewProps {
   showUiHint?: boolean;
   uiColor: string;
   theme: 'day' | 'night';
+  onToggleGrabMode: () => void;
+  isGrabMode: boolean;
 }
 
-const HiddenUiView = ({ onToggleUiHidden, showUiHint, uiColor, theme }: HiddenUiViewProps) => {
+const HiddenUiView = ({ onToggleUiHidden, showUiHint, uiColor, theme, onToggleGrabMode, isGrabMode }: HiddenUiViewProps) => {
   const isMobile = useIsMobile();
   const { isExpanded, toggleExpanded, isVisible } = useKeyboardShortcuts();
 
@@ -37,6 +39,26 @@ const HiddenUiView = ({ onToggleUiHidden, showUiHint, uiColor, theme }: HiddenUi
           <p>Show UI (Press V)</p>
         </TooltipContent>
       </Tooltip>
+
+      {/* Grab mode toggle */}
+      <div className="fixed top-4 left-4 z-50 pointer-events-auto">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon"
+              aria-label="Toggle Grab Mode"
+              onClick={onToggleGrabMode}
+              className="bg-black/30 hover:bg-black/50 text-white shadow-md"
+              style={{ color: uiColor }}
+            >
+              <Hand className="w-6 h-6" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{isGrabMode ? 'Disable' : 'Enable'} Grab Mode</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
 
       {/* Info icon when shortcuts are hidden */}
       {!isMobile && !isVisible && (

--- a/src/components/scene/DynamicObject.tsx
+++ b/src/components/scene/DynamicObject.tsx
@@ -6,14 +6,16 @@ import DistortionSphereObject from './objects/DistortionSphereObject';
 import MorphingIcosahedronObject from './objects/MorphingIcosahedronObject';
 import WavyGridObject from './objects/WavyGridObject';
 import CrystallineSpireObject from './objects/CrystallineSpireObject';
+import PhysicsPlaygroundObject from './objects/PhysicsPlaygroundObject';
 
 interface DynamicObjectProps {
   type: SceneConfig['type'];
   themeConfig: SceneThemeConfig;
   isLocked: boolean;
+  isGrabMode: boolean;
 }
 
-const DynamicObject = ({ type, themeConfig, isLocked }: DynamicObjectProps) => {
+const DynamicObject = ({ type, themeConfig, isLocked, isGrabMode }: DynamicObjectProps) => {
   const { mainObjectColor, material } = themeConfig;
   switch (type) {
     case 'TorusKnot':
@@ -28,6 +30,8 @@ const DynamicObject = ({ type, themeConfig, isLocked }: DynamicObjectProps) => {
       return <MorphingIcosahedronObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
     case 'WavyGrid':
       return <WavyGridObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
+    case 'PhysicsPlayground':
+      return <PhysicsPlaygroundObject isGrabMode={isGrabMode} />;
     default:
       return null;
   }

--- a/src/components/scene/DynamicWorld.tsx
+++ b/src/components/scene/DynamicWorld.tsx
@@ -8,9 +8,10 @@ import DynamicObject from './DynamicObject';
 interface DynamicWorldProps {
   sceneConfig: SceneConfig;
   isLocked: boolean;
+  isGrabMode: boolean;
 }
 
-const DynamicWorld = ({ sceneConfig, isLocked }: DynamicWorldProps) => {
+const DynamicWorld = ({ sceneConfig, isLocked, isGrabMode }: DynamicWorldProps) => {
   const { theme } = useExperience();
   const { type, day, night } = sceneConfig;
 
@@ -24,7 +25,7 @@ const DynamicWorld = ({ sceneConfig, isLocked }: DynamicWorldProps) => {
     <>
       <DynamicLights lights={themeConfig.lights} />
       <DynamicBackground background={themeConfig.background} extras={themeConfig.extras} />
-      <DynamicObject type={type} themeConfig={themeConfig} isLocked={isLocked} />
+      <DynamicObject type={type} themeConfig={themeConfig} isLocked={isLocked} isGrabMode={isGrabMode} />
     </>
   );
 };

--- a/src/components/scene/objects/PhysicsPlaygroundObject.tsx
+++ b/src/components/scene/objects/PhysicsPlaygroundObject.tsx
@@ -1,0 +1,61 @@
+import { usePlane, useBox, useSphere } from '@react-three/cannon'
+import { MeshWobbleMaterial } from '@react-three/drei'
+import { useThree, useFrame } from '@react-three/fiber'
+import { useRef, useState } from 'react'
+import { Vector3 } from 'three'
+
+interface PhysicsPlaygroundObjectProps {
+  isGrabMode: boolean;
+}
+
+function useDrag(api: any, isGrabMode: boolean) {
+  const { mouse, camera } = useThree()
+  const [drag, setDrag] = useState(false)
+  useFrame(() => {
+    if (drag) {
+      const vec = new Vector3(mouse.x, mouse.y, 0).unproject(camera)
+      api.position.set(vec.x, vec.y, vec.z)
+      api.velocity.set(0, 0, 0)
+    }
+  })
+  return {
+    onPointerDown: () => isGrabMode && setDrag(true),
+    onPointerUp: () => setDrag(false),
+    onPointerLeave: () => setDrag(false),
+  }
+}
+
+const JellyBox = ({ position, color, isGrabMode }: { position: [number, number, number]; color: string; isGrabMode: boolean }) => {
+  const [ref, api] = useBox(() => ({ mass: 1, position }))
+  const bind = useDrag(api, isGrabMode)
+  return (
+    <mesh ref={ref} castShadow receiveShadow {...bind}>
+      <boxGeometry args={[1, 1, 1]} />
+      <MeshWobbleMaterial color={color} factor={0.6} speed={2} />
+    </mesh>
+  )
+}
+
+const JellySphere = ({ position, color, isGrabMode }: { position: [number, number, number]; color: string; isGrabMode: boolean }) => {
+  const [ref, api] = useSphere(() => ({ mass: 1, position }))
+  const bind = useDrag(api, isGrabMode)
+  return (
+    <mesh ref={ref} castShadow receiveShadow {...bind}>
+      <sphereGeometry args={[0.6, 32, 32]} />
+      <MeshWobbleMaterial color={color} factor={0.7} speed={2} />
+    </mesh>
+  )
+}
+
+const PhysicsPlaygroundObject = ({ isGrabMode }: PhysicsPlaygroundObjectProps) => {
+  usePlane(() => ({ position: [0, -0.5, 0], rotation: [-Math.PI / 2, 0, 0] }))
+  return (
+    <>
+      <JellyBox position={[0, 1, 0]} color="#ff69b4" isGrabMode={isGrabMode} />
+      <JellySphere position={[2, 1, -1]} color="#87cefa" isGrabMode={isGrabMode} />
+      <JellyBox position={[-2, 1, 1]} color="#98fb98" isGrabMode={isGrabMode} />
+    </>
+  )
+}
+
+export default PhysicsPlaygroundObject

--- a/src/hooks/useExperienceState.ts
+++ b/src/hooks/useExperienceState.ts
@@ -12,6 +12,7 @@ export const useExperienceState = () => {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isUiHidden, setIsUiHidden] = useState(true);
+  const [isGrabMode, setIsGrabMode] = useState(false);
   const [showUiHint, setShowUiHint] = useState(false);
   const hintShownRef = useRef(false);
 
@@ -53,6 +54,8 @@ export const useExperienceState = () => {
     setIsSettingsOpen,
     isUiHidden,
     setIsUiHidden,
+    isGrabMode,
+    setIsGrabMode,
     showUiHint,
     setShowUiHint,
     hintShownRef,

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -115,7 +115,7 @@ export type SceneThemeConfig = {
 };
 
 export type SceneConfig = {
-  type: 'TorusKnot' | 'WobbleField' | 'DistortionSphere' | 'MorphingIcosahedron' | 'WavyGrid' | 'CrystallineSpire';
+  type: 'TorusKnot' | 'WobbleField' | 'DistortionSphere' | 'MorphingIcosahedron' | 'WavyGrid' | 'CrystallineSpire' | 'PhysicsPlayground';
   day: SceneThemeConfig;
   night: SceneThemeConfig;
 };

--- a/supabase/migrations/20250620072000-jelly-playground.sql
+++ b/supabase/migrations/20250620072000-jelly-playground.sql
@@ -1,0 +1,26 @@
+INSERT INTO public.worlds (name, description, scene_config)
+VALUES (
+  'Jelly Playground',
+  'A bouncy field of shapes you can grab and toss.',
+  '{
+    "type": "PhysicsPlayground",
+    "day": {
+      "mainObjectColor": "#ff69b4",
+      "material": { "roughness": 0.2 },
+      "background": { "type": "sky", "sunPosition": [5,5,5] },
+      "lights": [
+        { "type": "ambient", "intensity": 0.8 },
+        { "type": "directional", "position": [5,10,5], "intensity": 0.8 }
+      ]
+    },
+    "night": {
+      "mainObjectColor": "#ff69b4",
+      "material": { "roughness": 0.5 },
+      "background": { "type": "stars", "radius": 200, "depth": 50, "count": 2000, "factor": 4, "saturation": 0.5, "fade": true, "speed": 0.5 },
+      "lights": [
+        { "type": "ambient", "intensity": 0.2 },
+        { "type": "point", "position": [0,5,0], "intensity": 1.5, "color": "#ff69b4" }
+      ]
+    }
+  }'::jsonb
+);


### PR DESCRIPTION
## Summary
- introduce a PhysicsPlayground scene with draggable jelly objects
- support grab mode toggle when UI is hidden
- pass grab mode state through experience components
- include migration to register "Jelly Playground" world
- add @react-three/cannon dependency

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855098e1e048333b106b8eb2a78fea3