### PR TITLE
Add Jelly Playground scene with grab mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@react-three/cannon": "^6.6.0",
         "@react-three/drei": "^9.122.0",
         "@react-three/fiber": "^8.18.0",
         "@react-three/postprocessing": "^2.19.1",
@@ -1197,6 +1198,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pmndrs/cannon-worker-api": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@pmndrs/cannon-worker-api/-/cannon-worker-api-2.4.0.tgz",
+      "integrity": "sha512-oJA1Bboc+WObksRaGDKJG0Wna9Q75xi1MdXVAZ9qXzBOyPsadmAnrmiKOEF0R8v/4zsuJElvscNZmyo3msbZjA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.139"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2626,6 +2636,22 @@
       "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
       "license": "MIT"
     },
+    "node_modules/@react-three/cannon": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@react-three/cannon/-/cannon-6.6.0.tgz",
+      "integrity": "sha512-lP9rJoVHQi0w+dYF8FJAm2xr5eLfNEckb04j72kjqndUkuOPr26N4rSBhQbHl5b5N3tEnhQaIMungAvHkcY8/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@pmndrs/cannon-worker-api": "^2.4.0",
+        "cannon-es": "^0.20.0",
+        "cannon-es-debugger": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8",
+        "react": ">=18",
+        "three": ">=0.139"
+      }
+    },
     "node_modules/@react-three/drei": {
       "version": "9.122.0",
       "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
@@ -2783,7 +2809,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2797,7 +2822,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2811,7 +2835,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2825,7 +2848,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2839,7 +2861,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2853,7 +2874,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2867,7 +2887,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2881,7 +2900,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2895,7 +2913,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2909,7 +2926,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2923,7 +2939,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2937,7 +2952,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2951,7 +2965,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2965,7 +2978,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2979,7 +2991,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2993,7 +3004,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3007,7 +3017,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3021,7 +3030,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3035,7 +3043,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3049,7 +3056,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3568,7 +3574,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -4039,6 +4045,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -4275,6 +4293,28 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cannon-es": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/cannon-es/-/cannon-es-0.20.0.tgz",
+      "integrity": "sha512-eZhWTZIkFOnMAJOgfXJa9+b3kVlvG+FX4mdkpePev/w/rP5V8NRquGyEozcjPfEoXUlb+p7d9SUcmDSn14prOA==",
+      "license": "MIT"
+    },
+    "node_modules/cannon-es-debugger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cannon-es-debugger/-/cannon-es-debugger-1.0.0.tgz",
+      "integrity": "sha512-sE9lDOBAYFKlh+0w+cvWKwUhJef8HYnUSVPWPL0jD15MAuVRQKno4QYZSGxgOoJkMR3mQqxL4bxys2b3RSWH8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "cannon-es": "0.x",
+        "three": "0.x",
+        "typescript": ">=3.8"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5041,7 +5081,6 @@
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
       "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
@@ -5774,6 +5813,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6024,12 +6075,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -6571,6 +6622,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/recharts": {
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
@@ -6662,7 +6725,6 @@
       "version": "4.43.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.43.0.tgz",
       "integrity": "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.7"
@@ -6702,7 +6764,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -7128,7 +7189,6 @@
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
       "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.4.4",
@@ -7139,19 +7199,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -7281,7 +7328,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7466,7 +7513,6 @@
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -7535,19 +7581,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/webgl-constants": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
+    "@react-three/cannon": "^6.6.0",
     "@react-three/drei": "^9.122.0",
     "@react-three/fiber": "^8.18.0",
     "@react-three/postprocessing": "^2.19.1",

--- a/src/components/experience/ExperienceLayout.tsx
+++ b/src/components/experience/ExperienceLayout.tsx
@@ -9,6 +9,7 @@ interface ExperienceLayoutProps {
   isTransitioning: boolean;
   currentWorldIndex: number;
   isObjectLocked: boolean;
+  isGrabMode: boolean;
   onToggleObjectLock: () => void;
   isSettingsOpen: boolean;
   isMobile: boolean;
@@ -20,6 +21,7 @@ const ExperienceLayout = ({
   isTransitioning,
   currentWorldIndex,
   isObjectLocked,
+  isGrabMode,
   onToggleObjectLock,
   isSettingsOpen,
   isMobile,
@@ -28,12 +30,13 @@ const ExperienceLayout = ({
   if (isMobile) {
     return (
       <div className="w-full h-full">
-        <WorldView 
-          sceneConfig={editableSceneConfig} 
-          isTransitioning={isTransitioning} 
-          worldIndex={currentWorldIndex} 
-          isLocked={isObjectLocked} 
-          onToggleLock={onToggleObjectLock} 
+        <WorldView
+          sceneConfig={editableSceneConfig}
+          isTransitioning={isTransitioning}
+          worldIndex={currentWorldIndex}
+          isLocked={isObjectLocked}
+          isGrabMode={isGrabMode}
+          onToggleLock={onToggleObjectLock}
         />
       </div>
     );
@@ -43,12 +46,13 @@ const ExperienceLayout = ({
     <ResizablePanelGroup direction="horizontal">
       <ResizablePanel>
         <div className="w-full h-full relative">
-          <WorldView 
-            sceneConfig={editableSceneConfig} 
-            isTransitioning={isTransitioning} 
-            worldIndex={currentWorldIndex} 
-            isLocked={isObjectLocked} 
-            onToggleLock={onToggleObjectLock} 
+          <WorldView
+            sceneConfig={editableSceneConfig}
+            isTransitioning={isTransitioning}
+            worldIndex={currentWorldIndex}
+            isLocked={isObjectLocked}
+            isGrabMode={isGrabMode}
+            onToggleLock={onToggleObjectLock}
           />
         </div>
       </ResizablePanel>

--- a/src/components/experience/ExperienceLogic.tsx
+++ b/src/components/experience/ExperienceLogic.tsx
@@ -44,6 +44,8 @@ const ExperienceLogic = () => {
     setIsSettingsOpen,
     isUiHidden,
     setIsUiHidden,
+    isGrabMode,
+    setIsGrabMode,
     showUiHint,
     setShowUiHint,
     hintShownRef,
@@ -117,6 +119,7 @@ const ExperienceLogic = () => {
         isTransitioning={isTransitioning}
         currentWorldIndex={currentWorldIndex}
         isObjectLocked={isObjectLocked}
+        isGrabMode={isGrabMode}
         onToggleObjectLock={toggleObjectLock}
         isSettingsOpen={isSettingsOpen}
         isMobile={isMobile}
@@ -140,6 +143,8 @@ const ExperienceLogic = () => {
         onToggleSettings={setIsSettingsOpen}
         isUiHidden={isUiHidden}
         onToggleUiHidden={() => setIsUiHidden((h) => !h)}
+        isGrabMode={isGrabMode}
+        onToggleGrabMode={() => setIsGrabMode((g) => !g)}
         showUiHint={showUiHint}
       />
 

--- a/src/components/experience/ExperienceUI.tsx
+++ b/src/components/experience/ExperienceUI.tsx
@@ -25,6 +25,8 @@ interface ExperienceUIProps {
   onToggleSettings: (isOpen: boolean) => void;
   isUiHidden: boolean;
   onToggleUiHidden: () => void;
+  isGrabMode: boolean;
+  onToggleGrabMode: () => void;
   showUiHint?: boolean;
 }
 
@@ -45,6 +47,8 @@ const ExperienceUI = ({
   onToggleSettings,
   isUiHidden,
   onToggleUiHidden,
+  isGrabMode,
+  onToggleGrabMode,
   showUiHint = false,
 }: ExperienceUIProps) => {
   const isMobile = useIsMobile();
@@ -77,11 +81,13 @@ const ExperienceUI = ({
   if (isUiHidden) {
     return (
       <TooltipProvider>
-        <HiddenUiView 
+        <HiddenUiView
           onToggleUiHidden={onToggleUiHidden}
           showUiHint={showUiHint}
           uiColor={uiColor}
           theme={theme}
+          isGrabMode={isGrabMode}
+          onToggleGrabMode={onToggleGrabMode}
         />
       </TooltipProvider>
     );

--- a/src/components/experience/WorldView.tsx
+++ b/src/components/experience/WorldView.tsx
@@ -9,10 +9,11 @@ interface WorldViewProps {
   isTransitioning: boolean;
   worldIndex: number;
   isLocked: boolean;
+  isGrabMode: boolean;
   onToggleLock: () => void;
 }
 
-const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggleLock }: WorldViewProps) => {
+const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, isGrabMode, onToggleLock }: WorldViewProps) => {
   return (
     <div
       key={worldIndex}
@@ -20,7 +21,7 @@ const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggl
     >
       <WorldContainer onToggleLock={onToggleLock} isLocked={isLocked}>
         <KeyboardControls />
-        <DynamicWorld sceneConfig={sceneConfig} isLocked={isLocked} />
+        <DynamicWorld sceneConfig={sceneConfig} isLocked={isLocked} isGrabMode={isGrabMode} />
       </WorldContainer>
     </div>
   );

--- a/src/components/experience/ui/HiddenUiView.tsx
+++ b/src/components/experience/ui/HiddenUiView.tsx
@@ -1,7 +1,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Eye, ChevronDown, ChevronUp, Pointer, Info } from "lucide-react";
+import { Eye, ChevronDown, ChevronUp, Pointer, Info, Hand } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useKeyboardShortcuts } from "@/context/KeyboardShortcutsContext";
@@ -11,14 +11,27 @@ interface HiddenUiViewProps {
   showUiHint?: boolean;
   uiColor: string;
   theme: 'day' | 'night';
+  isGrabMode: boolean;
+  onToggleGrabMode: () => void;
 }
 
-const HiddenUiView = ({ onToggleUiHidden, showUiHint, uiColor, theme }: HiddenUiViewProps) => {
+const HiddenUiView = ({ onToggleUiHidden, showUiHint, uiColor, theme, isGrabMode, onToggleGrabMode }: HiddenUiViewProps) => {
   const isMobile = useIsMobile();
   const { isExpanded, toggleExpanded, isVisible } = useKeyboardShortcuts();
 
   return (
     <>
+      <div className="fixed top-4 left-4 z-50 pointer-events-auto">
+        <Button
+          size="icon"
+          aria-label="Toggle Grab Mode"
+          onClick={onToggleGrabMode}
+          className="bg-black/30 hover:bg-black/50 text-white shadow-md"
+          style={{ color: uiColor }}
+        >
+          <Hand className="w-6 h-6" />
+        </Button>
+      </div>
       <Tooltip open={showUiHint}>
         <TooltipTrigger asChild>
           <div className="fixed top-4 right-4 z-50 pointer-events-auto">

--- a/src/components/scene/DynamicObject.tsx
+++ b/src/components/scene/DynamicObject.tsx
@@ -6,28 +6,32 @@ import DistortionSphereObject from './objects/DistortionSphereObject';
 import MorphingIcosahedronObject from './objects/MorphingIcosahedronObject';
 import WavyGridObject from './objects/WavyGridObject';
 import CrystallineSpireObject from './objects/CrystallineSpireObject';
+import PhysicsPlaygroundObject from './objects/PhysicsPlaygroundObject';
 
 interface DynamicObjectProps {
   type: SceneConfig['type'];
   themeConfig: SceneThemeConfig;
   isLocked: boolean;
+  isGrabMode: boolean;
 }
 
-const DynamicObject = ({ type, themeConfig, isLocked }: DynamicObjectProps) => {
+const DynamicObject = ({ type, themeConfig, isLocked, isGrabMode }: DynamicObjectProps) => {
   const { mainObjectColor, material } = themeConfig;
   switch (type) {
     case 'TorusKnot':
-      return <TorusKnotObject themeConfig={themeConfig} isLocked={isLocked} />;
+      return <TorusKnotObject themeConfig={themeConfig} isLocked={isLocked} isGrabMode={isGrabMode} />;
     case 'WobbleField':
-      return <WobbleFieldObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
+      return <WobbleFieldObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} isGrabMode={isGrabMode} />;
     case 'CrystallineSpire':
-      return <CrystallineSpireObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
+      return <CrystallineSpireObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} isGrabMode={isGrabMode} />;
     case 'DistortionSphere':
-      return <DistortionSphereObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
+      return <DistortionSphereObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} isGrabMode={isGrabMode} />;
     case 'MorphingIcosahedron':
-      return <MorphingIcosahedronObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
+      return <MorphingIcosahedronObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} isGrabMode={isGrabMode} />;
     case 'WavyGrid':
-      return <WavyGridObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
+      return <WavyGridObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} isGrabMode={isGrabMode} />;
+    case 'PhysicsPlayground':
+      return <PhysicsPlaygroundObject isGrabMode={isGrabMode} />;
     default:
       return null;
   }

--- a/src/components/scene/DynamicWorld.tsx
+++ b/src/components/scene/DynamicWorld.tsx
@@ -8,9 +8,10 @@ import DynamicObject from './DynamicObject';
 interface DynamicWorldProps {
   sceneConfig: SceneConfig;
   isLocked: boolean;
+  isGrabMode: boolean;
 }
 
-const DynamicWorld = ({ sceneConfig, isLocked }: DynamicWorldProps) => {
+const DynamicWorld = ({ sceneConfig, isLocked, isGrabMode }: DynamicWorldProps) => {
   const { theme } = useExperience();
   const { type, day, night } = sceneConfig;
 
@@ -24,7 +25,12 @@ const DynamicWorld = ({ sceneConfig, isLocked }: DynamicWorldProps) => {
     <>
       <DynamicLights lights={themeConfig.lights} />
       <DynamicBackground background={themeConfig.background} extras={themeConfig.extras} />
-      <DynamicObject type={type} themeConfig={themeConfig} isLocked={isLocked} />
+      <DynamicObject
+        type={type}
+        themeConfig={themeConfig}
+        isLocked={isLocked}
+        isGrabMode={isGrabMode}
+      />
     </>
   );
 };

--- a/src/components/scene/objects/CrystallineSpireObject.tsx
+++ b/src/components/scene/objects/CrystallineSpireObject.tsx
@@ -13,6 +13,7 @@ interface CrystallineSpireObjectProps {
   color: string;
   materialConfig: MaterialConfig;
   isLocked: boolean;
+  isGrabMode: boolean; // unused but for API consistency
 }
 
 const CrystallineSpireObject = ({ color, materialConfig, isLocked }: CrystallineSpireObjectProps) => {

--- a/src/components/scene/objects/DistortionSphereObject.tsx
+++ b/src/components/scene/objects/DistortionSphereObject.tsx
@@ -9,6 +9,7 @@ interface DistortionSphereObjectProps {
   color: string;
   materialConfig: MaterialConfig;
   isLocked: boolean;
+  isGrabMode: boolean; // unused but for API consistency
 }
 
 const DistortionSphereObject = ({ color, materialConfig, isLocked }: DistortionSphereObjectProps) => {

--- a/src/components/scene/objects/MorphingIcosahedronObject.tsx
+++ b/src/components/scene/objects/MorphingIcosahedronObject.tsx
@@ -9,6 +9,7 @@ interface MorphingIcosahedronObjectProps {
   color: string;
   materialConfig: MaterialConfig;
   isLocked: boolean;
+  isGrabMode: boolean; // unused but for API consistency
 }
 
 const MorphingIcosahedronObject = ({ color, materialConfig, isLocked }: MorphingIcosahedronObjectProps) => {

--- a/src/components/scene/objects/PhysicsPlaygroundObject.tsx
+++ b/src/components/scene/objects/PhysicsPlaygroundObject.tsx
@@ -1,0 +1,75 @@
+import { Physics, useBox, usePlane } from '@react-three/cannon';
+import { MeshWobbleMaterial } from '@react-three/drei';
+import { useMemo, useRef, useState } from 'react';
+import { Vector3, Plane as ThreePlane } from 'three';
+
+interface PhysicsPlaygroundObjectProps {
+  isGrabMode: boolean;
+}
+
+const Jelly = ({ position, isGrabMode }: { position: [number, number, number]; isGrabMode: boolean }) => {
+  const [ref, api] = useBox(() => ({ mass: 1, position }));
+  const plane = useMemo(() => new ThreePlane(new Vector3(0, 1, 0), 0), []);
+  const intersection = useMemo(() => new Vector3(), []);
+  const offset = useRef(new Vector3());
+  const [dragging, setDragging] = useState(false);
+
+  const onPointerDown = (e: any) => {
+    if (!isGrabMode) return;
+    e.stopPropagation();
+    e.ray.intersectPlane(plane, intersection);
+    offset.current.copy(intersection).sub(ref.current.position);
+    setDragging(true);
+  };
+
+  const onPointerUp = () => {
+    setDragging(false);
+  };
+
+  const onPointerMove = (e: any) => {
+    if (!dragging) return;
+    e.ray.intersectPlane(plane, intersection);
+    api.position.set(
+      intersection.x - offset.current.x,
+      ref.current.position.y,
+      intersection.z - offset.current.z
+    );
+    api.velocity.set(0, 0, 0);
+  };
+
+  return (
+    <mesh
+      ref={ref}
+      castShadow
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerMove={onPointerMove}
+    >
+      <boxGeometry args={[1, 1, 1]} />
+      <MeshWobbleMaterial color="#ff69b4" speed={2} factor={0.6} />
+    </mesh>
+  );
+};
+
+const Floor = () => {
+  const [ref] = usePlane(() => ({ rotation: [-Math.PI / 2, 0, 0], position: [0, 0, 0] }));
+  return (
+    <mesh ref={ref} receiveShadow>
+      <planeGeometry args={[20, 20]} />
+      <meshStandardMaterial color="#444" />
+    </mesh>
+  );
+};
+
+const PhysicsPlaygroundObject = ({ isGrabMode }: PhysicsPlaygroundObjectProps) => {
+  return (
+    <Physics gravity={[0, -9.81, 0]}>
+      <Floor />
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Jelly key={i} position={[i - 2, 2 + i * 0.5, 0]} isGrabMode={isGrabMode} />
+      ))}
+    </Physics>
+  );
+};
+
+export default PhysicsPlaygroundObject;

--- a/src/components/scene/objects/TorusKnotObject.tsx
+++ b/src/components/scene/objects/TorusKnotObject.tsx
@@ -9,6 +9,7 @@ import DynamicMaterial from '../materials/DynamicMaterial';
 interface TorusKnotObjectProps {
   themeConfig: SceneThemeConfig;
   isLocked: boolean;
+  isGrabMode: boolean; // unused but for API consistency
 }
 
 const TorusKnotObject = ({ themeConfig, isLocked }: TorusKnotObjectProps) => {

--- a/src/components/scene/objects/WavyGridObject.tsx
+++ b/src/components/scene/objects/WavyGridObject.tsx
@@ -9,6 +9,7 @@ interface WavyGridObjectProps {
   color: string;
   materialConfig: MaterialConfig;
   isLocked: boolean;
+  isGrabMode: boolean; // unused but for API consistency
 }
 
 const WavyGridObject = ({ color, materialConfig, isLocked }: WavyGridObjectProps) => {

--- a/src/components/scene/objects/WobbleFieldObject.tsx
+++ b/src/components/scene/objects/WobbleFieldObject.tsx
@@ -10,6 +10,7 @@ interface WobbleFieldObjectProps {
   color: string;
   materialConfig: MaterialConfig;
   isLocked: boolean;
+  isGrabMode: boolean; // unused but for API consistency
 }
 
 const WobbleFieldObject = ({ color, materialConfig, isLocked }: WobbleFieldObjectProps) => {

--- a/src/hooks/useExperienceState.ts
+++ b/src/hooks/useExperienceState.ts
@@ -13,6 +13,7 @@ export const useExperienceState = () => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isUiHidden, setIsUiHidden] = useState(true);
   const [showUiHint, setShowUiHint] = useState(false);
+  const [isGrabMode, setIsGrabMode] = useState(false);
   const hintShownRef = useRef(false);
 
   const toggleObjectLock = useCallback(() => {
@@ -43,6 +44,8 @@ export const useExperienceState = () => {
     setEditableSceneConfig,
     isObjectLocked,
     toggleObjectLock,
+    isGrabMode,
+    setIsGrabMode,
     currentWorldId,
     setCurrentWorldId,
     isHelpOpen,

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -115,7 +115,14 @@ export type SceneThemeConfig = {
 };
 
 export type SceneConfig = {
-  type: 'TorusKnot' | 'WobbleField' | 'DistortionSphere' | 'MorphingIcosahedron' | 'WavyGrid' | 'CrystallineSpire';
+  type:
+    | 'TorusKnot'
+    | 'WobbleField'
+    | 'DistortionSphere'
+    | 'MorphingIcosahedron'
+    | 'WavyGrid'
+    | 'CrystallineSpire'
+    | 'PhysicsPlayground';
   day: SceneThemeConfig;
   night: SceneThemeConfig;
 };

--- a/supabase/migrations/20250618123000-add-jelly-playground.sql
+++ b/supabase/migrations/20250618123000-add-jelly-playground.sql
@@ -1,0 +1,25 @@
+INSERT INTO public.worlds (name, description, scene_config) VALUES (
+  'Jelly Playground',
+  'A physics sandbox of jiggly shapes.',
+  '{
+    "type": "PhysicsPlayground",
+    "day": {
+      "mainObjectColor": "#ff69b4",
+      "material": { "roughness": 0.2, "metalness": 0.3 },
+      "background": { "type": "color", "color": "#e0f7ff" },
+      "lights": [
+        { "type": "ambient", "intensity": 0.8 },
+        { "type": "directional", "position": [5, 10, 5], "intensity": 0.9 }
+      ]
+    },
+    "night": {
+      "mainObjectColor": "#ff69b4",
+      "material": { "roughness": 0.2, "metalness": 0.3 },
+      "background": { "type": "stars", "radius": 100, "depth": 30, "count": 500, "factor": 2, "saturation": 0.5, "fade": true, "speed": 1 },
+      "lights": [
+        { "type": "ambient", "intensity": 0.2 },
+        { "type": "point", "position": [0, 5, 0], "intensity": 1 }
+      ]
+    }
+  }'
+);


### PR DESCRIPTION
## Summary
- add `@react-three/cannon` for physics
- implement PhysicsPlaygroundObject with draggable jelly cubes
- wire grab mode through experience components
- show grab toggle button when UI is hidden
- register "Jelly Playground" world in migrations

## Testing
- `npm run lint` *(fails: 33 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6855110be7588333b15d41f7a6860d41