### PR TITLE
Add Jelly Playground physics world

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@react-three/cannon": "^6.6.0",
         "@react-three/drei": "^9.122.0",
         "@react-three/fiber": "^8.18.0",
         "@react-three/postprocessing": "^2.19.1",
@@ -1197,6 +1198,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pmndrs/cannon-worker-api": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@pmndrs/cannon-worker-api/-/cannon-worker-api-2.4.0.tgz",
+      "integrity": "sha512-oJA1Bboc+WObksRaGDKJG0Wna9Q75xi1MdXVAZ9qXzBOyPsadmAnrmiKOEF0R8v/4zsuJElvscNZmyo3msbZjA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.139"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2625,6 +2635,22 @@
       "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
       "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
       "license": "MIT"
+    },
+    "node_modules/@react-three/cannon": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@react-three/cannon/-/cannon-6.6.0.tgz",
+      "integrity": "sha512-lP9rJoVHQi0w+dYF8FJAm2xr5eLfNEckb04j72kjqndUkuOPr26N4rSBhQbHl5b5N3tEnhQaIMungAvHkcY8/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@pmndrs/cannon-worker-api": "^2.4.0",
+        "cannon-es": "^0.20.0",
+        "cannon-es-debugger": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8",
+        "react": ">=18",
+        "three": ">=0.139"
+      }
     },
     "node_modules/@react-three/drei": {
       "version": "9.122.0",
@@ -4275,6 +4301,28 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cannon-es": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/cannon-es/-/cannon-es-0.20.0.tgz",
+      "integrity": "sha512-eZhWTZIkFOnMAJOgfXJa9+b3kVlvG+FX4mdkpePev/w/rP5V8NRquGyEozcjPfEoXUlb+p7d9SUcmDSn14prOA==",
+      "license": "MIT"
+    },
+    "node_modules/cannon-es-debugger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cannon-es-debugger/-/cannon-es-debugger-1.0.0.tgz",
+      "integrity": "sha512-sE9lDOBAYFKlh+0w+cvWKwUhJef8HYnUSVPWPL0jD15MAuVRQKno4QYZSGxgOoJkMR3mQqxL4bxys2b3RSWH8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "cannon-es": "0.x",
+        "three": "0.x",
+        "typescript": ">=3.8"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@react-three/drei": "^9.122.0",
     "@react-three/fiber": "^8.18.0",
     "@react-three/postprocessing": "^2.19.1",
+    "@react-three/cannon": "^6.6.0",
     "@supabase/supabase-js": "^2.50.0",
     "@tanstack/react-query": "^5.56.2",
     "@vitejs/plugin-react": "^4.5.2",

--- a/src/components/WorldContainer.tsx
+++ b/src/components/WorldContainer.tsx
@@ -8,16 +8,17 @@ type WorldContainerProps = {
   children: React.ReactNode;
   onToggleLock?: () => void;
   isLocked: boolean;
+  isGrabMode?: boolean;
 };
 
-const WorldContainer = ({ children, onToggleLock, isLocked }: WorldContainerProps) => {
+const WorldContainer = ({ children, onToggleLock, isLocked, isGrabMode = false }: WorldContainerProps) => {
   const [isDragging, setIsDragging] = useState(false);
 
   return (
     <Canvas 
       camera={{ position: [0, 0, 5], fov: 75 }} 
       onDoubleClick={onToggleLock}
-      style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
+      style={{ cursor: isDragging ? 'grabbing' : isGrabMode ? 'grab' : 'auto' }}
       onPointerDown={() => setIsDragging(true)}
       onPointerUp={() => setIsDragging(false)}
       onPointerLeave={() => setIsDragging(false)}
@@ -32,6 +33,7 @@ const WorldContainer = ({ children, onToggleLock, isLocked }: WorldContainerProp
         autoRotateSpeed={0.5}
         minDistance={2}
         maxDistance={25}
+        enabled={!isGrabMode}
         onStart={() => setIsDragging(true)}
         onEnd={() => setIsDragging(false)}
       />

--- a/src/components/experience/ExperienceHotkeys.tsx
+++ b/src/components/experience/ExperienceHotkeys.tsx
@@ -10,6 +10,7 @@ interface ExperienceHotkeysProps {
   handleGoHome: () => void;
   handleCopyCode: () => void;
   toggleObjectLock: () => void;
+  toggleGrabMode: () => void;
   handleToggleShortcuts: () => void;
   setIsSearchOpen: (open: boolean) => void;
   setIsHelpOpen: (open: boolean) => void;
@@ -28,6 +29,7 @@ const ExperienceHotkeys = ({
   handleGoHome,
   handleCopyCode,
   toggleObjectLock,
+  toggleGrabMode,
   handleToggleShortcuts,
   setIsSearchOpen,
   setIsHelpOpen,
@@ -76,6 +78,7 @@ const ExperienceHotkeys = ({
       copyCode: handleCopyCode,
       toggleUi: () => setIsUiHidden(o => !o),
       toggleLock: toggleObjectLock,
+      toggleGrabMode: toggleGrabMode,
       toggleShortcuts: handleToggleShortcuts
     },
     enabled: !isHelpOpen && !isSearchOpen && !isSettingsOpen,

--- a/src/components/experience/ExperienceLayout.tsx
+++ b/src/components/experience/ExperienceLayout.tsx
@@ -10,6 +10,8 @@ interface ExperienceLayoutProps {
   currentWorldIndex: number;
   isObjectLocked: boolean;
   onToggleObjectLock: () => void;
+  isGrabMode: boolean;
+  onToggleGrabMode?: () => void;
   isSettingsOpen: boolean;
   isMobile: boolean;
   onUpdateSceneConfig: (config: SceneConfig) => void;
@@ -21,6 +23,8 @@ const ExperienceLayout = ({
   currentWorldIndex,
   isObjectLocked,
   onToggleObjectLock,
+  isGrabMode,
+  onToggleGrabMode,
   isSettingsOpen,
   isMobile,
   onUpdateSceneConfig,
@@ -28,12 +32,14 @@ const ExperienceLayout = ({
   if (isMobile) {
     return (
       <div className="w-full h-full">
-        <WorldView 
-          sceneConfig={editableSceneConfig} 
-          isTransitioning={isTransitioning} 
-          worldIndex={currentWorldIndex} 
-          isLocked={isObjectLocked} 
-          onToggleLock={onToggleObjectLock} 
+        <WorldView
+          sceneConfig={editableSceneConfig}
+          isTransitioning={isTransitioning}
+          worldIndex={currentWorldIndex}
+          isLocked={isObjectLocked}
+          onToggleLock={onToggleObjectLock}
+          isGrabMode={isGrabMode}
+          onToggleGrabMode={onToggleGrabMode}
         />
       </div>
     );

--- a/src/components/experience/ExperienceLogic.tsx
+++ b/src/components/experience/ExperienceLogic.tsx
@@ -44,6 +44,8 @@ const ExperienceLogic = () => {
     setIsSettingsOpen,
     isUiHidden,
     setIsUiHidden,
+    isGrabMode,
+    setIsGrabMode,
     showUiHint,
     setShowUiHint,
     hintShownRef,
@@ -140,6 +142,8 @@ const ExperienceLogic = () => {
         onToggleSettings={setIsSettingsOpen}
         isUiHidden={isUiHidden}
         onToggleUiHidden={() => setIsUiHidden((h) => !h)}
+        isGrabMode={isGrabMode}
+        onToggleGrabMode={() => setIsGrabMode((g) => !g)}
         showUiHint={showUiHint}
       />
 
@@ -149,6 +153,7 @@ const ExperienceLogic = () => {
         handleGoHome={handleGoHome}
         handleCopyCode={handleCopyCode}
         toggleObjectLock={toggleObjectLock}
+        toggleGrabMode={() => setIsGrabMode(g => !g)}
         handleToggleShortcuts={handleToggleShortcuts}
         setIsSearchOpen={setIsSearchOpen}
         setIsHelpOpen={setIsHelpOpen}

--- a/src/components/experience/ExperienceUI.tsx
+++ b/src/components/experience/ExperienceUI.tsx
@@ -25,6 +25,8 @@ interface ExperienceUIProps {
   onToggleSettings: (isOpen: boolean) => void;
   isUiHidden: boolean;
   onToggleUiHidden: () => void;
+  isGrabMode: boolean;
+  onToggleGrabMode: () => void;
   showUiHint?: boolean;
 }
 
@@ -45,6 +47,8 @@ const ExperienceUI = ({
   onToggleSettings,
   isUiHidden,
   onToggleUiHidden,
+  isGrabMode,
+  onToggleGrabMode,
   showUiHint = false,
 }: ExperienceUIProps) => {
   const isMobile = useIsMobile();
@@ -77,8 +81,10 @@ const ExperienceUI = ({
   if (isUiHidden) {
     return (
       <TooltipProvider>
-        <HiddenUiView 
+        <HiddenUiView
           onToggleUiHidden={onToggleUiHidden}
+          onToggleGrabMode={onToggleGrabMode}
+          isGrabMode={isGrabMode}
           showUiHint={showUiHint}
           uiColor={uiColor}
           theme={theme}

--- a/src/components/experience/WorldView.tsx
+++ b/src/components/experience/WorldView.tsx
@@ -10,17 +10,19 @@ interface WorldViewProps {
   worldIndex: number;
   isLocked: boolean;
   onToggleLock: () => void;
+  isGrabMode?: boolean;
+  onToggleGrabMode?: () => void;
 }
 
-const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggleLock }: WorldViewProps) => {
+const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggleLock, isGrabMode = false, onToggleGrabMode }: WorldViewProps) => {
   return (
     <div
       key={worldIndex}
       className={`w-full h-full absolute inset-0 transition-all duration-1000 ${isTransitioning ? 'opacity-0 scale-95' : 'opacity-100 scale-100'}`}
     >
-      <WorldContainer onToggleLock={onToggleLock} isLocked={isLocked}>
+      <WorldContainer onToggleLock={onToggleLock} isLocked={isLocked} isGrabMode={isGrabMode}>
         <KeyboardControls />
-        <DynamicWorld sceneConfig={sceneConfig} isLocked={isLocked} />
+        <DynamicWorld sceneConfig={sceneConfig} isLocked={isLocked} isGrabMode={isGrabMode} onToggleGrabMode={onToggleGrabMode} />
       </WorldContainer>
     </div>
   );

--- a/src/components/experience/ui/HiddenUiView.tsx
+++ b/src/components/experience/ui/HiddenUiView.tsx
@@ -1,24 +1,44 @@
 
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Eye, ChevronDown, ChevronUp, Pointer, Info } from "lucide-react";
+import { Eye, ChevronDown, ChevronUp, Pointer, Info, Hand } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useKeyboardShortcuts } from "@/context/KeyboardShortcutsContext";
 
 interface HiddenUiViewProps {
   onToggleUiHidden: () => void;
+  onToggleGrabMode: () => void;
+  isGrabMode: boolean;
   showUiHint?: boolean;
   uiColor: string;
   theme: 'day' | 'night';
 }
 
-const HiddenUiView = ({ onToggleUiHidden, showUiHint, uiColor, theme }: HiddenUiViewProps) => {
+const HiddenUiView = ({ onToggleUiHidden, onToggleGrabMode, isGrabMode, showUiHint, uiColor, theme }: HiddenUiViewProps) => {
   const isMobile = useIsMobile();
   const { isExpanded, toggleExpanded, isVisible } = useKeyboardShortcuts();
 
   return (
     <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="fixed top-4 left-4 z-50 pointer-events-auto">
+            <Button
+              size="icon"
+              aria-label="Toggle Grab Mode"
+              onClick={onToggleGrabMode}
+              className="bg-black/30 hover:bg-black/50 text-white shadow-md cursor-pointer"
+              style={{ color: uiColor }}
+            >
+              <Hand className="w-6 h-6" />
+            </Button>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p>{isGrabMode ? 'Disable Grab' : 'Enable Grab'} (Press B)</p>
+        </TooltipContent>
+      </Tooltip>
       <Tooltip open={showUiHint}>
         <TooltipTrigger asChild>
           <div className="fixed top-4 right-4 z-50 pointer-events-auto">
@@ -88,6 +108,7 @@ const HiddenUiView = ({ onToggleUiHidden, showUiHint, uiColor, theme }: HiddenUi
                 <p>Press <span className="font-bold">P</span> to go to the previous world</p>
                 <p>Press <span className="font-bold">Space</span> to change the time of day</p>
                 <p>Press <span className="font-bold">.</span> to freeze or unfreeze objects</p>
+                <p>Press <span className="font-bold">B</span> to toggle grab mode</p>
                 <p>Press <span className="font-bold">V</span> to show or hide the interface</p>
                 <p>Press <span className="font-bold">E</span> to open scene settings</p>
                 <p>Press <span className="font-bold">S</span> to search for worlds</p>

--- a/src/components/scene/DynamicObject.tsx
+++ b/src/components/scene/DynamicObject.tsx
@@ -6,14 +6,17 @@ import DistortionSphereObject from './objects/DistortionSphereObject';
 import MorphingIcosahedronObject from './objects/MorphingIcosahedronObject';
 import WavyGridObject from './objects/WavyGridObject';
 import CrystallineSpireObject from './objects/CrystallineSpireObject';
+import PhysicsPlaygroundObject from './objects/PhysicsPlaygroundObject';
 
 interface DynamicObjectProps {
   type: SceneConfig['type'];
   themeConfig: SceneThemeConfig;
   isLocked: boolean;
+  isGrabMode?: boolean;
+  onToggleGrabMode?: () => void;
 }
 
-const DynamicObject = ({ type, themeConfig, isLocked }: DynamicObjectProps) => {
+const DynamicObject = ({ type, themeConfig, isLocked, isGrabMode = false, onToggleGrabMode }: DynamicObjectProps) => {
   const { mainObjectColor, material } = themeConfig;
   switch (type) {
     case 'TorusKnot':
@@ -28,6 +31,8 @@ const DynamicObject = ({ type, themeConfig, isLocked }: DynamicObjectProps) => {
       return <MorphingIcosahedronObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
     case 'WavyGrid':
       return <WavyGridObject color={mainObjectColor} materialConfig={material} isLocked={isLocked} />;
+    case 'PhysicsPlayground':
+      return <PhysicsPlaygroundObject isGrabMode={isGrabMode} onToggleGrabMode={onToggleGrabMode} />;
     default:
       return null;
   }

--- a/src/components/scene/DynamicWorld.tsx
+++ b/src/components/scene/DynamicWorld.tsx
@@ -8,9 +8,11 @@ import DynamicObject from './DynamicObject';
 interface DynamicWorldProps {
   sceneConfig: SceneConfig;
   isLocked: boolean;
+  isGrabMode?: boolean;
+  onToggleGrabMode?: () => void;
 }
 
-const DynamicWorld = ({ sceneConfig, isLocked }: DynamicWorldProps) => {
+const DynamicWorld = ({ sceneConfig, isLocked, isGrabMode = false, onToggleGrabMode }: DynamicWorldProps) => {
   const { theme } = useExperience();
   const { type, day, night } = sceneConfig;
 
@@ -24,7 +26,7 @@ const DynamicWorld = ({ sceneConfig, isLocked }: DynamicWorldProps) => {
     <>
       <DynamicLights lights={themeConfig.lights} />
       <DynamicBackground background={themeConfig.background} extras={themeConfig.extras} />
-      <DynamicObject type={type} themeConfig={themeConfig} isLocked={isLocked} />
+      <DynamicObject type={type} themeConfig={themeConfig} isLocked={isLocked} isGrabMode={isGrabMode} onToggleGrabMode={onToggleGrabMode} />
     </>
   );
 };

--- a/src/components/scene/objects/PhysicsPlaygroundObject.tsx
+++ b/src/components/scene/objects/PhysicsPlaygroundObject.tsx
@@ -1,0 +1,70 @@
+import { Physics, usePlane, useBox, useSphere } from '@react-three/cannon';
+import { MeshWobbleMaterial } from '@react-three/drei';
+import { useThree } from '@react-three/fiber';
+import { useRef } from 'react';
+import { Vector3 } from 'three';
+
+interface PhysicsPlaygroundObjectProps {
+  isGrabMode: boolean;
+  onToggleGrabMode?: () => void;
+}
+
+const DraggableJelly = ({ position, color, isGrabMode }: { position: [number, number, number]; color: string; isGrabMode: boolean; }) => {
+  const [ref, api] = useSphere(() => ({ mass: 1, position }));
+  const { size, camera } = useThree();
+  const dragging = useRef(false);
+
+  const handlePointerDown = (e: any) => {
+    if (!isGrabMode) return;
+    e.stopPropagation();
+    dragging.current = true;
+    api.mass.set(0); // hold in place
+    api.velocity.set(0, 0, 0);
+  };
+
+  const handlePointerMove = (e: any) => {
+    if (!dragging.current) return;
+    const x = (e.clientX / size.width) * 2 - 1;
+    const y = -(e.clientY / size.height) * 2 + 1;
+    const vec = new Vector3(x, y, 0.5).unproject(camera);
+    api.position.copy(vec);
+  };
+
+  const handlePointerUp = () => {
+    if (!dragging.current) return;
+    dragging.current = false;
+    api.mass.set(1);
+  };
+
+  return (
+    <mesh
+      ref={ref as any}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      castShadow
+    >
+      <sphereGeometry args={[0.5, 32, 32]} />
+      <MeshWobbleMaterial color={color} speed={2} factor={0.6} />
+    </mesh>
+  );
+};
+
+const PhysicsPlaygroundObject = ({ isGrabMode }: PhysicsPlaygroundObjectProps) => {
+  const [planeRef] = usePlane(() => ({ rotation: [-Math.PI / 2, 0, 0] }));
+  const colors = ['#f87171', '#60a5fa', '#34d399', '#fbbf24'];
+
+  return (
+    <Physics gravity={[0, -9.8, 0]}>
+      <mesh ref={planeRef as any} receiveShadow position={[0, -1, 0]}>
+        <planeGeometry args={[20, 20]} />
+        <meshStandardMaterial color="#222" />
+      </mesh>
+      {colors.map((c, i) => (
+        <DraggableJelly key={i} position={[i - 1.5, 2 + i, 0]} color={c} isGrabMode={isGrabMode} />
+      ))}
+    </Physics>
+  );
+};
+
+export default PhysicsPlaygroundObject;

--- a/src/hooks/useExperienceHotkeys.ts
+++ b/src/hooks/useExperienceHotkeys.ts
@@ -13,6 +13,7 @@ interface HotkeyCallbacks {
   copyCode: () => void;
   toggleUi: () => void;
   toggleLock: () => void;
+  toggleGrabMode: () => void;
   toggleShortcuts: () => void;
 }
 
@@ -33,6 +34,7 @@ export const useExperienceHotkeys = ({ callbacks, enabled }: useExperienceHotkey
     onCopyCode: actions.copyCode,
     onToggleUi: actions.toggleUi,
     onToggleLock: actions.handleToggleLock,
+    onToggleGrabMode: actions.handleToggleGrabMode,
     onToggleShortcuts: actions.handleToggleShortcuts,
     enabled,
   });

--- a/src/hooks/useExperienceState.ts
+++ b/src/hooks/useExperienceState.ts
@@ -12,6 +12,7 @@ export const useExperienceState = () => {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isUiHidden, setIsUiHidden] = useState(true);
+  const [isGrabMode, setIsGrabMode] = useState(false);
   const [showUiHint, setShowUiHint] = useState(false);
   const hintShownRef = useRef(false);
 
@@ -53,6 +54,8 @@ export const useExperienceState = () => {
     setIsSettingsOpen,
     isUiHidden,
     setIsUiHidden,
+    isGrabMode,
+    setIsGrabMode,
     showUiHint,
     setShowUiHint,
     hintShownRef,

--- a/src/hooks/useHotkeyActions.ts
+++ b/src/hooks/useHotkeyActions.ts
@@ -12,6 +12,7 @@ interface HotkeyActionCallbacks {
   copyCode: () => void;
   toggleUi: () => void;
   toggleLock: () => void;
+  toggleGrabMode: () => void;
   toggleShortcuts: () => void;
 }
 
@@ -32,6 +33,11 @@ export const useHotkeyActions = (callbacks: HotkeyActionCallbacks) => {
     logEvent({ eventType: 'keyboard_shortcut', eventSource: 'toggle_lock' });
   }, [callbacks]);
 
+  const handleToggleGrabMode = useCallback(() => {
+    callbacks.toggleGrabMode();
+    logEvent({ eventType: 'keyboard_shortcut', eventSource: 'toggle_grab' });
+  }, [callbacks]);
+
   const handleOpenHelp = useCallback(() => {
     callbacks.openHelp();
     logEvent({ eventType: 'keyboard_shortcut', eventSource: 'open_help' });
@@ -46,6 +52,7 @@ export const useHotkeyActions = (callbacks: HotkeyActionCallbacks) => {
     handleToggleTheme,
     handleToggleShortcuts,
     handleToggleLock,
+    handleToggleGrabMode,
     handleOpenHelp,
     handleToggleSettings,
     changeWorld: callbacks.changeWorld,

--- a/src/hooks/useKeyboardEventHandler.ts
+++ b/src/hooks/useKeyboardEventHandler.ts
@@ -12,6 +12,7 @@ interface KeyboardEventHandlerProps {
   onCopyCode: () => void;
   onToggleUi: () => void;
   onToggleLock: () => void;
+  onToggleGrabMode: () => void;
   onToggleShortcuts: () => void;
   enabled: boolean;
 }
@@ -115,6 +116,13 @@ export const useKeyboardEventHandler = ({
           onToggleUi();
         }
         break;
+
+      case 'KeyB':
+        if (!typing) {
+          event.preventDefault();
+          onToggleGrabMode();
+        }
+        break;
       
       case 'Period':
         if (!typing) {
@@ -134,6 +142,7 @@ export const useKeyboardEventHandler = ({
     onCopyCode,
     onToggleUi,
     onToggleLock,
+    onToggleGrabMode,
     onToggleShortcuts,
   ]);
 

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -115,7 +115,7 @@ export type SceneThemeConfig = {
 };
 
 export type SceneConfig = {
-  type: 'TorusKnot' | 'WobbleField' | 'DistortionSphere' | 'MorphingIcosahedron' | 'WavyGrid' | 'CrystallineSpire';
+  type: 'TorusKnot' | 'WobbleField' | 'DistortionSphere' | 'MorphingIcosahedron' | 'WavyGrid' | 'CrystallineSpire' | 'PhysicsPlayground';
   day: SceneThemeConfig;
   night: SceneThemeConfig;
 };

--- a/supabase/migrations/20250620080000-jelly-playground-world.sql
+++ b/supabase/migrations/20250620080000-jelly-playground-world.sql
@@ -1,0 +1,5 @@
+INSERT INTO public.worlds (name, description, scene_config) VALUES (
+  'Jelly Playground',
+  'A physics sandbox of bouncy blobs.',
+  '{"type":"PhysicsPlayground","day":{"mainObjectColor":"#f87171","material":{"roughness":0.3,"metalness":0.1},"background":{"type":"sky","sunPosition":[10,10,5]},"lights":[{"type":"ambient","intensity":1},{"type":"directional","position":[5,10,5],"intensity":0.8}]},"night":{"mainObjectColor":"#60a5fa","material":{"roughness":0.2,"metalness":0.5},"background":{"type":"stars","radius":150,"depth":50,"count":2000,"factor":4,"saturation":0.2,"fade":true,"speed":1},"lights":[{"type":"ambient","intensity":0.2},{"type":"point","position":[0,5,0],"intensity":1,"color":"#60a5fa"}]}}'
+);


### PR DESCRIPTION
## Summary
- add `@react-three/cannon` for physics
- enable grab mode across experience components
- show grab toggle when UI is hidden
- implement `PhysicsPlaygroundObject` with draggable jelly spheres
- register "Jelly Playground" world in Supabase

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685515561aa4833383708a8c8a9e8e6b