### PR TITLE
Add framer-motion world transitions and slug-based routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.2.0",
     "embla-carousel-react": "^8.3.0",
+    "framer-motion": "^12.18.1",
     "input-otp": "^1.2.4",
     "lil-gui": "^0.19.2",
     "lovable-tagger": "^1.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ const App = () => (
         
           <Route path="/" element={<HomePage />} />
         
-          <Route path="/experience" element={<ExperiencePage />} />
+          <Route path="/experience/:slug?" element={<ExperiencePage />} />
           
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />

--- a/src/components/experience/ExperienceContent.tsx
+++ b/src/components/experience/ExperienceContent.tsx
@@ -2,10 +2,14 @@
 import { KeyboardShortcutsProvider } from "@/context/KeyboardShortcutsContext";
 import ExperienceLogic from "./ExperienceLogic";
 
-const ExperienceContent = () => {
+interface ExperienceContentProps {
+  initialSlug?: string;
+}
+
+const ExperienceContent = ({ initialSlug }: ExperienceContentProps) => {
   return (
     <KeyboardShortcutsProvider>
-      <ExperienceLogic />
+      <ExperienceLogic initialSlug={initialSlug} />
     </KeyboardShortcutsProvider>
   );
 };

--- a/src/components/experience/ExperienceLayout.tsx
+++ b/src/components/experience/ExperienceLayout.tsx
@@ -3,6 +3,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/componen
 import { SceneConfig } from "@/types/scene";
 import WorldView from "./WorldView";
 import SceneSettingsPanel from "./SceneSettingsPanel";
+import { AnimatePresence } from "framer-motion";
 
 interface ExperienceLayoutProps {
   editableSceneConfig: SceneConfig;
@@ -28,13 +29,15 @@ const ExperienceLayout = ({
   if (isMobile) {
     return (
       <div className="w-full h-full">
-        <WorldView 
-          sceneConfig={editableSceneConfig} 
-          isTransitioning={isTransitioning} 
-          worldIndex={currentWorldIndex} 
-          isLocked={isObjectLocked} 
-          onToggleLock={onToggleObjectLock} 
-        />
+        <AnimatePresence mode="wait">
+          <WorldView
+            sceneConfig={editableSceneConfig}
+            isTransitioning={isTransitioning}
+            worldIndex={currentWorldIndex}
+            isLocked={isObjectLocked}
+            onToggleLock={onToggleObjectLock}
+          />
+        </AnimatePresence>
       </div>
     );
   }
@@ -43,13 +46,15 @@ const ExperienceLayout = ({
     <ResizablePanelGroup direction="horizontal">
       <ResizablePanel>
         <div className="w-full h-full relative">
-          <WorldView 
-            sceneConfig={editableSceneConfig} 
-            isTransitioning={isTransitioning} 
-            worldIndex={currentWorldIndex} 
-            isLocked={isObjectLocked} 
-            onToggleLock={onToggleObjectLock} 
-          />
+          <AnimatePresence mode="wait">
+            <WorldView
+              sceneConfig={editableSceneConfig}
+              isTransitioning={isTransitioning}
+              worldIndex={currentWorldIndex}
+              isLocked={isObjectLocked}
+              onToggleLock={onToggleObjectLock}
+            />
+          </AnimatePresence>
         </div>
       </ResizablePanel>
       {isSettingsOpen && (

--- a/src/components/experience/ExperienceLogic.tsx
+++ b/src/components/experience/ExperienceLogic.tsx
@@ -14,7 +14,10 @@ import ExperienceHotkeys from "./ExperienceHotkeys";
 import ExperienceTransitions from "./ExperienceTransitions";
 import ExperienceLayout from "./ExperienceLayout";
 
-const ExperienceLogic = () => {
+interface ExperienceLogicProps {
+  initialSlug?: string;
+}
+const ExperienceLogic = ({ initialSlug }: ExperienceLogicProps) => {
   const {
     worlds,
     isLoading,
@@ -24,7 +27,7 @@ const ExperienceLogic = () => {
     isTransitioning,
     changeWorld,
     jumpToWorld,
-  } = useWorlds();
+  } = useWorlds(initialSlug);
   
   const { theme, toggleTheme } = useExperience();
   const isMobile = useIsMobile();

--- a/src/components/experience/WorldView.tsx
+++ b/src/components/experience/WorldView.tsx
@@ -3,6 +3,7 @@ import WorldContainer from "@/components/WorldContainer";
 import KeyboardControls from "@/components/controls/KeyboardControls";
 import DynamicWorld from "@/components/scene/DynamicWorld";
 import { SceneConfig } from "@/types/scene";
+import { motion } from "framer-motion";
 
 interface WorldViewProps {
   sceneConfig: SceneConfig;
@@ -14,15 +15,19 @@ interface WorldViewProps {
 
 const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggleLock }: WorldViewProps) => {
   return (
-    <div
+    <motion.div
       key={worldIndex}
-      className={`w-full h-full absolute inset-0 transition-all duration-1000 ${isTransitioning ? 'opacity-0 scale-95' : 'opacity-100 scale-100'}`}
+      className="w-full h-full fixed inset-0"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 1 }}
     >
       <WorldContainer onToggleLock={onToggleLock} isLocked={isLocked}>
         <KeyboardControls />
         <DynamicWorld sceneConfig={sceneConfig} isLocked={isLocked} />
       </WorldContainer>
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/components/home/HomePageContent.tsx
+++ b/src/components/home/HomePageContent.tsx
@@ -2,6 +2,7 @@
 import { useNavigate } from "react-router-dom";
 import BackgroundScene from "@/components/BackgroundScene";
 import { useExperience } from "@/hooks/useExperience";
+import { FIRST_WORLD_SLUG } from "@/lib/featureFlags";
 import { useEffect, useState, useCallback } from "react";
 import TransitionSplash from "@/components/TransitionSplash";
 import ThemeToggle from "./ThemeToggle";
@@ -22,7 +23,7 @@ const HomePageContent = () => {
     setShowSplash(true);
     
     setTimeout(() => {
-      navigate("/experience");
+      navigate(`/experience/${FIRST_WORLD_SLUG}`);
     }, 1850);
   }, [isLeaving, navigate]);
 

--- a/src/hooks/useWorlds.ts
+++ b/src/hooks/useWorlds.ts
@@ -1,20 +1,35 @@
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import type { Database } from "@/integrations/supabase/types";
+import { isWorldEnabled } from "@/lib/featureFlags";
+import { useNavigate } from "react-router-dom";
 
-type World = Database['public']['Tables']['worlds']['Row'];
+type WorldRow = Database['public']['Tables']['worlds']['Row'];
+export interface World extends WorldRow {
+  slug: string;
+}
+
+const slugify = (name: string) =>
+  name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "");
 
 const fetchWorlds = async (): Promise<World[]> => {
   const { data, error } = await supabase.from('worlds').select('*').order('id', { ascending: true });
   if (error) throw new Error(error.message);
-  return data || [];
+  const rows = (data || []) as WorldRow[];
+  return rows
+    .map((w) => ({ ...w, slug: slugify(w.name) }))
+    .filter((w) => isWorldEnabled(w.slug));
 };
 
-export const useWorlds = () => {
+export const useWorlds = (initialSlug?: string) => {
   const [currentWorldIndex, setCurrentWorldIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const navigate = useNavigate();
 
   const { data: worlds, isLoading, isError } = useQuery<World[]>({
     queryKey: ['worlds'],
@@ -25,6 +40,22 @@ export const useWorlds = () => {
     if (!worlds || worlds.length === 0) return null;
     return worlds[currentWorldIndex];
   }, [worlds, currentWorldIndex]);
+
+  useEffect(() => {
+    if (!worlds) return;
+    if (initialSlug) {
+      const idx = worlds.findIndex((w) => w.slug === initialSlug);
+      if (idx >= 0) {
+        setCurrentWorldIndex(idx);
+      }
+    }
+  }, [initialSlug, worlds]);
+
+  useEffect(() => {
+    if (worlds && worlds[currentWorldIndex]) {
+      navigate(`/experience/${worlds[currentWorldIndex].slug}`, { replace: true });
+    }
+  }, [worlds, currentWorldIndex, navigate]);
 
   const changeWorld = useCallback((direction: 'next' | 'prev') => {
     if (isTransitioning || !worlds || worlds.length === 0) return;

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,10 @@
+export const ENABLED_WORLD_SLUGS = [
+  'genesis-torus',
+  'distortion-sphere',
+  'wobble-field',
+  'crystalline-spire',
+];
+
+export const FIRST_WORLD_SLUG = ENABLED_WORLD_SLUGS[0];
+
+export const isWorldEnabled = (slug: string) => ENABLED_WORLD_SLUGS.includes(slug);

--- a/src/pages/ExperiencePage.tsx
+++ b/src/pages/ExperiencePage.tsx
@@ -1,20 +1,21 @@
 
 import { useEffect } from "react";
+import { useParams } from "react-router-dom";
 import { ExperienceProvider } from "@/context/ExperienceContext";
 import ExperienceContent from "@/components/experience/ExperienceContent";
 
 const ExperiencePage = () => {
 
+  const { slug } = useParams<{ slug?: string }>();
+
   useEffect(() => {
-  
     document.body.style.opacity = '1';
-  
   }, []);
 
   return (
   
     <ExperienceProvider>
-      <ExperienceContent />
+      <ExperienceContent initialSlug={slug} />
     </ExperienceProvider>
   
   );


### PR DESCRIPTION
## Summary
- integrate framer-motion
- sync current world slug with the router
- create feature flags for visible worlds
- animate world transitions with framer-motion
- start the experience at the first world slug
- fix world canvas resizing during transitions

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6856d377a2588333aac3db6bcc5d6ba6