### PR TITLE
Add slug-based world routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.2.0",
     "embla-carousel-react": "^8.3.0",
+    "framer-motion": "^12.18.1",
     "input-otp": "^1.2.4",
     "lil-gui": "^0.19.2",
     "lovable-tagger": "^1.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ const App = () => (
         
           <Route path="/" element={<HomePage />} />
         
-          <Route path="/experience" element={<ExperiencePage />} />
+          <Route path="/experience/:slug?" element={<ExperiencePage />} />
           
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />

--- a/src/components/experience/ExperienceContent.tsx
+++ b/src/components/experience/ExperienceContent.tsx
@@ -2,10 +2,14 @@
 import { KeyboardShortcutsProvider } from "@/context/KeyboardShortcutsContext";
 import ExperienceLogic from "./ExperienceLogic";
 
-const ExperienceContent = () => {
+interface ExperienceContentProps {
+  slug?: string;
+}
+
+const ExperienceContent = ({ slug }: ExperienceContentProps) => {
   return (
     <KeyboardShortcutsProvider>
-      <ExperienceLogic />
+      <ExperienceLogic slug={slug} />
     </KeyboardShortcutsProvider>
   );
 };

--- a/src/components/experience/ExperienceLayout.tsx
+++ b/src/components/experience/ExperienceLayout.tsx
@@ -2,6 +2,7 @@
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { SceneConfig } from "@/types/scene";
 import WorldView from "./WorldView";
+import { AnimatePresence } from "framer-motion";
 import SceneSettingsPanel from "./SceneSettingsPanel";
 
 interface ExperienceLayoutProps {
@@ -28,13 +29,16 @@ const ExperienceLayout = ({
   if (isMobile) {
     return (
       <div className="w-full h-full">
-        <WorldView 
-          sceneConfig={editableSceneConfig} 
-          isTransitioning={isTransitioning} 
-          worldIndex={currentWorldIndex} 
-          isLocked={isObjectLocked} 
-          onToggleLock={onToggleObjectLock} 
-        />
+        <AnimatePresence mode="wait">
+          <WorldView
+            key={currentWorldIndex}
+            sceneConfig={editableSceneConfig}
+            isTransitioning={isTransitioning}
+            worldIndex={currentWorldIndex}
+            isLocked={isObjectLocked}
+            onToggleLock={onToggleObjectLock}
+          />
+        </AnimatePresence>
       </div>
     );
   }
@@ -42,15 +46,18 @@ const ExperienceLayout = ({
   return (
     <ResizablePanelGroup direction="horizontal">
       <ResizablePanel>
-        <div className="w-full h-full relative">
-          <WorldView 
-            sceneConfig={editableSceneConfig} 
-            isTransitioning={isTransitioning} 
-            worldIndex={currentWorldIndex} 
-            isLocked={isObjectLocked} 
-            onToggleLock={onToggleObjectLock} 
-          />
-        </div>
+          <div className="w-full h-full relative">
+            <AnimatePresence mode="wait">
+              <WorldView
+                key={currentWorldIndex}
+                sceneConfig={editableSceneConfig}
+                isTransitioning={isTransitioning}
+                worldIndex={currentWorldIndex}
+                isLocked={isObjectLocked}
+                onToggleLock={onToggleObjectLock}
+              />
+            </AnimatePresence>
+          </div>
       </ResizablePanel>
       {isSettingsOpen && (
         <>

--- a/src/components/experience/ExperienceLogic.tsx
+++ b/src/components/experience/ExperienceLogic.tsx
@@ -14,7 +14,11 @@ import ExperienceHotkeys from "./ExperienceHotkeys";
 import ExperienceTransitions from "./ExperienceTransitions";
 import ExperienceLayout from "./ExperienceLayout";
 
-const ExperienceLogic = () => {
+interface ExperienceLogicProps {
+  slug?: string;
+}
+
+const ExperienceLogic = ({ slug }: ExperienceLogicProps) => {
   const {
     worlds,
     isLoading,
@@ -24,7 +28,7 @@ const ExperienceLogic = () => {
     isTransitioning,
     changeWorld,
     jumpToWorld,
-  } = useWorlds();
+  } = useWorlds(slug);
   
   const { theme, toggleTheme } = useExperience();
   const isMobile = useIsMobile();

--- a/src/components/experience/WorldView.tsx
+++ b/src/components/experience/WorldView.tsx
@@ -3,6 +3,7 @@ import WorldContainer from "@/components/WorldContainer";
 import KeyboardControls from "@/components/controls/KeyboardControls";
 import DynamicWorld from "@/components/scene/DynamicWorld";
 import { SceneConfig } from "@/types/scene";
+import { motion } from "framer-motion";
 
 interface WorldViewProps {
   sceneConfig: SceneConfig;
@@ -14,15 +15,19 @@ interface WorldViewProps {
 
 const WorldView = ({ sceneConfig, isTransitioning, worldIndex, isLocked, onToggleLock }: WorldViewProps) => {
   return (
-    <div
+    <motion.div
       key={worldIndex}
-      className={`w-full h-full absolute inset-0 transition-all duration-1000 ${isTransitioning ? 'opacity-0 scale-95' : 'opacity-100 scale-100'}`}
+      className="w-full h-full absolute inset-0"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.5 }}
     >
       <WorldContainer onToggleLock={onToggleLock} isLocked={isLocked}>
         <KeyboardControls />
         <DynamicWorld sceneConfig={sceneConfig} isLocked={isLocked} />
       </WorldContainer>
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,4 @@
+export const isFeatureEnabled = (flag: string): boolean => {
+  const key = `VITE_FEATURE_${flag.toUpperCase()}`;
+  return import.meta.env[key] === 'true';
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const slugify = (text: string): string =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')

--- a/src/pages/ExperiencePage.tsx
+++ b/src/pages/ExperiencePage.tsx
@@ -1,5 +1,6 @@
 
 import { useEffect } from "react";
+import { useParams } from "react-router-dom";
 import { ExperienceProvider } from "@/context/ExperienceContext";
 import ExperienceContent from "@/components/experience/ExperienceContent";
 
@@ -11,12 +12,12 @@ const ExperiencePage = () => {
   
   }, []);
 
+  const { slug } = useParams<{ slug?: string }>();
+
   return (
-  
     <ExperienceProvider>
-      <ExperienceContent />
+      <ExperienceContent slug={slug} />
     </ExperienceProvider>
-  
   );
 
 };


### PR DESCRIPTION
## Summary
- allow slug routing to experience worlds
- add framer-motion for animated world transitions
- expose `slugify` utility and feature flag helper
- fade between worlds with AnimatePresence

## Testing
- `bun run build`
- `bun run lint` *(fails: @typescript-eslint/no-explicit-any and no-require-imports errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856ef7b9eac8333a968801ad3b2cc10