### PR TITLE
codex: fix world slug pass-through

### DIFF
--- a/src/hooks/useExperienceEffects.ts
+++ b/src/hooks/useExperienceEffects.ts
@@ -37,9 +37,11 @@ export const useExperienceEffects = ({
         if (isSettingsOpen) {
           setIsSettingsOpen(false);
         }
+
+        handleEntryTransitionEnd();
       }
     }
-  }, [worldData, currentWorldId, isSettingsOpen, setEditableSceneConfig, setCurrentWorldId, setIsSettingsOpen]);
+  }, [worldData, currentWorldId, isSettingsOpen, setEditableSceneConfig, setCurrentWorldId, setIsSettingsOpen, handleEntryTransitionEnd]);
 
   // Settings escape key effect
   useEffect(() => {

--- a/src/pages/WorldExperiencePage.tsx
+++ b/src/pages/WorldExperiencePage.tsx
@@ -21,7 +21,7 @@ const WorldExperiencePage = () => {
   return (
 
     <ExperienceProvider>
-      <ExperienceContent initialWorldSlug={worldSlug} />
+      <ExperienceContent initialWorldSlug={world.slug} />
     </ExperienceProvider>
   
   );


### PR DESCRIPTION
## Summary
- ensure the experience page passes the validated world slug

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `bun install`
- `npm run lint` *(fails: 35 errors, 10 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685710f8583083338f217274afd83402