### PR TITLE
Fix initial canvas resize

### DIFF
--- a/src/components/WorldContainer.tsx
+++ b/src/components/WorldContainer.tsx
@@ -22,8 +22,8 @@ const WorldContainer = ({ children, onToggleLock, isLocked }: WorldContainerProp
       onDoubleClick={onToggleLock}
       style={{
         cursor: isDragging ? 'grabbing' : 'grab',
-        width: '100%',
-        height: '100%'
+        width: '100dvw',
+        height: '100dvh'
       }}
       onPointerDown={() => setIsDragging(true)}
       onPointerUp={() => setIsDragging(false)}

--- a/src/components/experience/ExperienceLogic.tsx
+++ b/src/components/experience/ExperienceLogic.tsx
@@ -161,7 +161,7 @@ const ExperienceLogic = ({ initialWorldSlug }: ExperienceLogicProps) => {
 
   return (
 
-    <div className="w-full h-full relative overflow-hidden bg-black">
+    <div className="fixed inset-0 overflow-hidden bg-black">
 
       <AnimatePresence mode="wait">
 

--- a/src/index.css
+++ b/src/index.css
@@ -42,7 +42,7 @@
   }
 
   html, body, #root {
-    width: 100%;
+    width: 100dvw;
     height: 100dvh;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
## Summary
- ensure viewport units use full available screen
- set canvas style to match dynamic viewport size

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685767153cec83339a247f28073bedd6