### PR TITLE
Fix initial canvas resize

### DIFF
--- a/src/components/WorldContainer.tsx
+++ b/src/components/WorldContainer.tsx
@@ -22,8 +22,8 @@ const WorldContainer = ({ children, onToggleLock, isLocked }: WorldContainerProp
       onDoubleClick={onToggleLock}
       style={{
         cursor: isDragging ? 'grabbing' : 'grab',
-        width: '100%',
-        height: '100%'
+        width: 'var(--app-width)',
+        height: 'var(--app-height)'
       }}
       onPointerDown={() => setIsDragging(true)}
       onPointerUp={() => setIsDragging(false)}

--- a/src/components/experience/ExperienceLogic.tsx
+++ b/src/components/experience/ExperienceLogic.tsx
@@ -161,7 +161,7 @@ const ExperienceLogic = ({ initialWorldSlug }: ExperienceLogicProps) => {
 
   return (
 
-    <div className="w-full h-full relative overflow-hidden bg-black">
+    <div className="fixed inset-0 overflow-hidden bg-black">
 
       <AnimatePresence mode="wait">
 

--- a/src/index.css
+++ b/src/index.css
@@ -42,8 +42,8 @@
   }
 
   html, body, #root {
-    width: 100%;
-    height: 100dvh;
+    width: var(--app-width, 100vw);
+    height: var(--app-height, 100vh);
     margin: 0;
     padding: 0;
     overflow: hidden;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,13 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
+const setViewportUnits = () => {
+  const root = document.documentElement
+  root.style.setProperty('--app-height', `${window.innerHeight}px`)
+  root.style.setProperty('--app-width', `${window.innerWidth}px`)
+}
+
+setViewportUnits()
+window.addEventListener('resize', setViewportUnits)
+
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
## Summary
- ensure viewport units use custom CSS variables
- update WorldContainer and global CSS to use app width/height
- set variables on window resize

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685767153cec83339a247f28073bedd6