### PR TITLE
Feature: hex color validation utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Informational modal in scene settings panel with usage tips.
 - Added zoom controls via mouse wheel/pinch and set zoom limits.
 - Added several new "environment" presets for scene backgrounds (sunset, dawn, night, etc.).
+- Validation helper `isValidHexColor` for consistent color checks.
 - GitHub Actions workflow (`.github/workflows/build-and-deploy.yml`) to automatically build and deploy the application to GitHub Pages on pushes to the `main` branch.
 - Configuration in `vite.config.ts` to set the `base` path for production builds, enabling correct asset loading on GitHub Pages.
 - Updated `src/App.tsx` to configure `BrowserRouter` with a dynamic `basename` to ensure correct client-side routing on GitHub Pages.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ If you find this project useful and want to support future development, consider
     -   `C`: Copy Scene Configuration
 -   **Live Scene Editor:** Click the settings icon to open a control panel (`lil-gui`) and adjust scene parameters like colors, materials, and object properties in real-time. The editor appears in a resizable side panel on desktop and a drawer on mobile. Now with more controls for materials and environment backgrounds!
 -   **Copy Configuration:** Easily copy the JSON configuration of your customized scene to your clipboard.
+-   **Input Validation:** Scene editor checks that color values are valid hex strings.
 -   **Supabase Integration:** World data is fetched from a Supabase backend.
 -   **Responsive UI:** The interface is designed to work across different screen sizes with optimized layouts for mobile and desktop.
 -   **Stable Rendering:** Improved theme switching without visual artifacts or rendering issues.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,3 +20,9 @@ export function darkenColor(hex: string, amount: number): string {
   const b = Math.max(0, Math.round((num & 0xff) * (1 - amount)))
   return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
 }
+
+export const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}){1,2}$/
+
+export function isValidHexColor(color: string): boolean {
+  return HEX_COLOR_REGEX.test(color)
+}

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeText, validateEmail } from './validation';
+import { isValidHexColor } from './utils';
+
+describe('validation utilities', () => {
+  it('sanitizes text by removing tags and limiting length', () => {
+    const input = '<script>alert(1)</script>'.repeat(10);
+    const sanitized = sanitizeText(input);
+    expect(sanitized.includes('<')).toBe(false);
+    expect(sanitized.length).toBeLessThanOrEqual(10000);
+  });
+
+  it('validates email addresses correctly', () => {
+    expect(validateEmail('test@example.com')).toBe(true);
+    expect(validateEmail('bad-email')).toBe(false);
+  });
+
+  it('checks for valid hex color strings', () => {
+    expect(isValidHexColor('#fff')).toBe(true);
+    expect(isValidHexColor('#abcdef')).toBe(true);
+    expect(isValidHexColor('#123abz')).toBe(false);
+    expect(isValidHexColor('red')).toBe(false);
+  });
+});

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -47,16 +47,18 @@ export const githubIssueSchema = z.object({
 });
 
 // Scene settings validation schema
+import { HEX_COLOR_REGEX } from './utils';
+
 export const sceneSettingsSchema = z.object({
   mainObjectColor: z.string()
-    .regex(/^#[0-9A-Fa-f]{6}$/, 'Invalid color format'),
+    .regex(HEX_COLOR_REGEX, 'Invalid color format'),
   
   material: z.object({
     materialType: z.enum(['standard', 'physical', 'toon', 'lambert', 'phong', 'normal', 'basic', 'matcap']).optional(),
     wireframe: z.boolean().optional(),
     roughness: z.number().min(0).max(1).optional(),
     metalness: z.number().min(0).max(1).optional(),
-    emissive: z.string().regex(/^#[0-9A-Fa-f]{6}$/).optional(),
+    emissive: z.string().regex(HEX_COLOR_REGEX).optional(),
     emissiveIntensity: z.number().min(0).max(10).optional(),
     transparent: z.boolean().optional(),
     opacity: z.number().min(0).max(1).optional(),


### PR DESCRIPTION
## Summary
- add `isValidHexColor` and regex helper
- use `HEX_COLOR_REGEX` in scene validation
- document input validation in README
- note change in CHANGELOG
- add tests for validation utilities

## Codex CI
- `npm ci --legacy-peer-deps`
- `npm run build`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860309a1abc83339fa3d28027fd743c