### PR TITLE
Feature: color validation utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added zoom controls via mouse wheel/pinch and set zoom limits.
 - Added several new "environment" presets for scene backgrounds (sunset, dawn, night, etc.).
 - GitHub Actions workflow (`.github/workflows/build-and-deploy.yml`) to automatically build and deploy the application to GitHub Pages on pushes to the `main` branch.
+- Added `isHexColor` utility to validate hex color strings.
 - Configuration in `vite.config.ts` to set the `base` path for production builds, enabling correct asset loading on GitHub Pages.
 - Updated `src/App.tsx` to configure `BrowserRouter` with a dynamic `basename` to ensure correct client-side routing on GitHub Pages.
 - **Persistent UI State:** UI visibility preferences are now preserved across world navigation using localStorage.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ If you find this project useful and want to support future development, consider
 -   **Supabase Integration:** World data is fetched from a Supabase backend.
 -   **Responsive UI:** The interface is designed to work across different screen sizes with optimized layouts for mobile and desktop.
 -   **Stable Rendering:** Improved theme switching without visual artifacts or rendering issues.
+-   **Color Utilities:** Functions to lighten, darken, and validate hex colors.
 </details>
 
 <details>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lightenColor, darkenColor } from './utils';
+import { lightenColor, darkenColor, isHexColor } from './utils';
 
 describe('color utilities', () => {
   it('lightens black by 50%', () => {
@@ -8,5 +8,12 @@ describe('color utilities', () => {
 
   it('darkens white by 50%', () => {
     expect(darkenColor('#ffffff', 0.5)).toBe('#808080');
+  });
+
+  it('validates hex colors correctly', () => {
+    expect(isHexColor('#fff')).toBe(true);
+    expect(isHexColor('#123ABC')).toBe(true);
+    expect(isHexColor('123456')).toBe(false);
+    expect(isHexColor('#12G')).toBe(false);
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,3 +20,7 @@ export function darkenColor(hex: string, amount: number): string {
   const b = Math.max(0, Math.round((num & 0xff) * (1 - amount)))
   return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
 }
+
+export function isHexColor(value: string): boolean {
+  return /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(value)
+}


### PR DESCRIPTION
## Summary
- add `isHexColor` util for checking hex color strings
- test new util in utils.test.ts
- document color utilities in README
- document new util in CHANGELOG

## Codex CI
- `npm ci --legacy-peer-deps`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68603065130483338a39f1bc8708a97c