### PR TITLE
Feature: automatic text contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added several new "environment" presets for scene backgrounds (sunset, dawn, night, etc.).
 - GitHub Actions workflow (`.github/workflows/build-and-deploy.yml`) to automatically build and deploy the application to GitHub Pages on pushes to the `main` branch.
 - Added `isHexColor` utility to validate hex color strings.
+- Added `getContrastingTextColor` utility to automatically choose black or white text based on background color.
 - Configuration in `vite.config.ts` to set the `base` path for production builds, enabling correct asset loading on GitHub Pages.
 - Updated `src/App.tsx` to configure `BrowserRouter` with a dynamic `basename` to ensure correct client-side routing on GitHub Pages.
 - **Persistent UI State:** UI visibility preferences are now preserved across world navigation using localStorage.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ If you find this project useful and want to support future development, consider
 -   **Supabase Integration:** World data is fetched from a Supabase backend.
 -   **Responsive UI:** The interface is designed to work across different screen sizes with optimized layouts for mobile and desktop.
 -   **Stable Rendering:** Improved theme switching without visual artifacts or rendering issues.
--   **Color Utilities:** Functions to lighten, darken, and validate hex colors.
+-   **Color Utilities:** Functions to lighten, darken, validate hex colors, and automatically choose a high-contrast text color.
 </details>
 
 <details>

--- a/src/components/experience/ui/BottomBar.tsx
+++ b/src/components/experience/ui/BottomBar.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/drawer";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import SceneControls from "@/components/scene/SceneControls";
+import { getContrastingTextColor } from "@/lib/utils";
 import { SceneConfig } from "@/types/scene";
 import { Copy, Settings, HelpCircle, Search } from "lucide-react";
 
@@ -48,8 +49,8 @@ const BottomBar = ({
 }: BottomBarProps) => {
   const blendedButtonClasses = "border-0 bg-black/40 hover:bg-black/60 dark:bg-white/40 dark:hover:bg-white/60";
   
-  // Use black text/icons in day mode for better visibility against bright backgrounds
-  const textColor = theme === 'day' ? '#000000' : uiColor;
+  // Use black text/icons in day mode and choose high-contrast color at night
+  const textColor = theme === 'day' ? '#000000' : getContrastingTextColor(uiColor);
   const uiStyle = { color: textColor };
 
   return (

--- a/src/components/experience/ui/HiddenUiView.tsx
+++ b/src/components/experience/ui/HiddenUiView.tsx
@@ -5,6 +5,7 @@ import { Eye, ChevronDown, ChevronUp, Pointer, Info } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useKeyboardShortcuts } from "@/context/KeyboardShortcutsContext";
+import { getContrastingTextColor } from "@/lib/utils";
 
 interface HiddenUiViewProps {
   onToggleUiHidden: () => void;
@@ -19,7 +20,7 @@ const HiddenUiView = ({ onToggleUiHidden, showUiHint, uiColor, theme }: HiddenUi
 
   // Use consistent button styling matching the main UI
   const blendedButtonClasses = "border-0 bg-black/40 hover:bg-black/60 dark:bg-white/40 dark:hover:bg-white/60";
-  const textColor = theme === 'day' ? '#000000' : uiColor;
+  const textColor = theme === 'day' ? '#000000' : getContrastingTextColor(uiColor);
   const uiStyle = { color: textColor };
 
   return (

--- a/src/components/experience/ui/NavigationControls.tsx
+++ b/src/components/experience/ui/NavigationControls.tsx
@@ -2,6 +2,7 @@
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import { getContrastingTextColor } from "@/lib/utils";
 
 interface NavigationControlsProps {
   uiColor: string;
@@ -13,8 +14,8 @@ interface NavigationControlsProps {
 const NavigationControls = ({ uiColor, onChangeWorld, isTransitioning, theme }: NavigationControlsProps) => {
   const blendedButtonClasses = "border-0 bg-black/40 hover:bg-black/60 dark:bg-white/40 dark:hover:bg-white/60";
   
-  // Use black text/icons in day mode for better visibility against bright backgrounds
-  const textColor = theme === 'day' ? '#000000' : uiColor;
+  // Use black text/icons in day mode and choose high-contrast color at night
+  const textColor = theme === 'day' ? '#000000' : getContrastingTextColor(uiColor);
   const uiStyle = { color: textColor };
 
   return (

--- a/src/components/experience/ui/TopBar.tsx
+++ b/src/components/experience/ui/TopBar.tsx
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from "react";
+import { getContrastingTextColor } from "@/lib/utils";
 import { useInstructions } from "@/hooks/useInstructions";
 import LikeDialog from "./LikeDialog";
 import InfoTooltip from "./InfoTooltip";
@@ -30,8 +31,8 @@ const TopBar = ({
 }: TopBarProps) => {
   const blendedButtonClasses = "border-0 bg-black/40 hover:bg-black/60 dark:bg-white/40 dark:hover:bg-white/60";
   
-  // Use black text in day mode for better visibility against bright backgrounds
-  const textColor = theme === 'day' ? '#000000' : uiColor;
+  // Use black text in day mode and choose high-contrast color at night
+  const textColor = theme === 'day' ? '#000000' : getContrastingTextColor(uiColor);
   const uiStyle = { color: textColor };
 
   // Stable state management with proper initialization

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lightenColor, darkenColor, isHexColor } from './utils';
+import { lightenColor, darkenColor, isHexColor, getContrastingTextColor } from './utils';
 
 describe('color utilities', () => {
   it('lightens black by 50%', () => {
@@ -15,5 +15,13 @@ describe('color utilities', () => {
     expect(isHexColor('#123ABC')).toBe(true);
     expect(isHexColor('123456')).toBe(false);
     expect(isHexColor('#12G')).toBe(false);
+  });
+
+  it('returns black text for light backgrounds', () => {
+    expect(getContrastingTextColor('#ffffff')).toBe('#000000');
+  });
+
+  it('returns white text for dark backgrounds', () => {
+    expect(getContrastingTextColor('#000000')).toBe('#ffffff');
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -24,3 +24,12 @@ export function darkenColor(hex: string, amount: number): string {
 export function isHexColor(value: string): boolean {
   return /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(value)
 }
+
+export function getContrastingTextColor(hex: string): string {
+  const normalized = hex.replace('#', '')
+  const r = parseInt(normalized.length === 3 ? normalized[0] + normalized[0] : normalized.slice(0, 2), 16)
+  const g = parseInt(normalized.length === 3 ? normalized[1] + normalized[1] : normalized.slice(2, 4), 16)
+  const b = parseInt(normalized.length === 3 ? normalized[2] + normalized[2] : normalized.slice(4, 6), 16)
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000
+  return yiq >= 128 ? '#000000' : '#ffffff'
+}


### PR DESCRIPTION
## Summary
- add `getContrastingTextColor` utility for dynamic text color
- apply contrast logic to top bar and control components
- document new utility in README and CHANGELOG
- test `getContrastingTextColor`

## Codex CI
- `npm ci --legacy-peer-deps`
- `npm run build`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686050690b208333bd53c61ce7e02e46