### PR TITLE
Feature: shorthand hex color utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Normalize `normalizeHexColor` utility and support for shorthand 3-digit hex colors in color helpers.
 - Initial project setup with Vite, React, TypeScript, and Supabase.
 - Dynamic 3D scenes with `react-three-fiber`.
 - World switching functionality with improved transitions.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If you find this project useful and want to support future development, consider
 -   **Supabase Integration:** World data is fetched from a Supabase backend.
 -   **Responsive UI:** The interface is designed to work across different screen sizes with optimized layouts for mobile and desktop.
 -   **Stable Rendering:** Improved theme switching without visual artifacts or rendering issues.
--   **Color Utilities:** Functions to lighten, darken, validate hex colors, and automatically choose a high-contrast text color.
+-   **Color Utilities:** Functions to lighten, darken, validate hex colors, automatically choose a high-contrast text color, and now support shorthand 3-digit hex codes.
 </details>
 
 <details>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -10,6 +10,14 @@ describe('color utilities', () => {
     expect(darkenColor('#ffffff', 0.5)).toBe('#808080');
   });
 
+  it('lightens shorthand hex colors', () => {
+    expect(lightenColor('#abc', 0.5)).toBe(lightenColor('#aabbcc', 0.5));
+  });
+
+  it('darkens shorthand hex colors', () => {
+    expect(darkenColor('#abc', 0.5)).toBe(darkenColor('#aabbcc', 0.5));
+  });
+
   it('validates hex colors correctly', () => {
     expect(isHexColor('#fff')).toBe(true);
     expect(isHexColor('#123ABC')).toBe(true);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,8 +5,17 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function normalizeHexColor(hex: string): string {
+  const sanitized = hex.replace('#', '')
+  if (sanitized.length === 3) {
+    return `#${sanitized[0]}${sanitized[0]}${sanitized[1]}${sanitized[1]}${sanitized[2]}${sanitized[2]}`
+  }
+  return hex.startsWith('#') ? hex : `#${sanitized}`
+}
+
 export function lightenColor(hex: string, amount: number): string {
-  const num = parseInt(hex.replace('#', ''), 16)
+  const normalized = normalizeHexColor(hex).replace('#', '')
+  const num = parseInt(normalized, 16)
   const r = Math.min(255, Math.round((num >> 16) + (255 - (num >> 16)) * amount))
   const g = Math.min(255, Math.round(((num >> 8) & 0xff) + (255 - ((num >> 8) & 0xff)) * amount))
   const b = Math.min(255, Math.round((num & 0xff) + (255 - (num & 0xff)) * amount))
@@ -14,7 +23,8 @@ export function lightenColor(hex: string, amount: number): string {
 }
 
 export function darkenColor(hex: string, amount: number): string {
-  const num = parseInt(hex.replace('#', ''), 16)
+  const normalized = normalizeHexColor(hex).replace('#', '')
+  const num = parseInt(normalized, 16)
   const r = Math.max(0, Math.round((num >> 16) * (1 - amount)))
   const g = Math.max(0, Math.round(((num >> 8) & 0xff) * (1 - amount)))
   const b = Math.max(0, Math.round((num & 0xff) * (1 - amount)))
@@ -26,7 +36,7 @@ export function isHexColor(value: string): boolean {
 }
 
 export function getContrastingTextColor(hex: string): string {
-  const normalized = hex.replace('#', '')
+  const normalized = normalizeHexColor(hex).replace('#', '')
   const r = parseInt(normalized.length === 3 ? normalized[0] + normalized[0] : normalized.slice(0, 2), 16)
   const g = parseInt(normalized.length === 3 ? normalized[1] + normalized[1] : normalized.slice(2, 4), 16)
   const b = parseInt(normalized.length === 3 ? normalized[2] + normalized[2] : normalized.slice(4, 6), 16)


### PR DESCRIPTION
## Summary
- support shorthand hex colors via `normalizeHexColor`
- test color utilities with shorthand hex codes
- document color utilities update
- note change in changelog

## Codex CI
- `npm ci --legacy-peer-deps`
- `npm run build`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68629335850c8333b52e943e44a48333