### PR TITLE
Cleanup: style update for forehead and chin

### DIFF
--- a/src/components/experience/ui/BottomBar.tsx
+++ b/src/components/experience/ui/BottomBar.tsx
@@ -1,5 +1,4 @@
 
-import { Button } from "@/components/ui/button";
 import {
   Sheet,
   SheetContent,
@@ -40,9 +39,13 @@ const BottomBar = ({
   isDragEnabled,
   onToggleDrag,
 }: BottomBarProps) => {
+  const barClasses = theme === 'day'
+    ? 'bg-white/80 border-t border-gray-200'
+    : 'bg-gray-900/80 border-t border-gray-700';
+
   return (
-    <div 
-      className="fixed bottom-4 left-0 right-0 w-full flex items-center justify-between px-4 sm:px-8 z-30 pointer-events-none"
+    <div
+      className={`fixed bottom-0 left-0 right-0 w-full py-3 px-4 sm:px-8 pointer-events-none flex items-center justify-between backdrop-blur-md shadow-[var(--shadow-elegant)] z-30 ${barClasses}`}
     >
       {/* Left side: Copy, Search, Drag Toggle */}
       <div className="flex gap-2 pointer-events-auto">

--- a/src/components/experience/ui/TopBar.tsx
+++ b/src/components/experience/ui/TopBar.tsx
@@ -70,10 +70,14 @@ const TopBar = ({
 
   const buttonStyle = { ...uiStyle, ...textStyle };
 
+  const barClasses = theme === 'day'
+    ? 'bg-white/80 border-b border-gray-200'
+    : 'bg-gray-900/80 border-b border-gray-700';
+
   return (
-    <div 
-      style={textStyle} 
-      className={`absolute top-0 left-0 w-full p-4 sm:p-8 pointer-events-none flex justify-between items-start transition-opacity duration-300 ${
+    <div
+      style={textStyle}
+      className={`absolute top-0 left-0 w-full p-4 sm:p-8 pointer-events-none flex justify-between items-start transition-opacity duration-300 backdrop-blur-md shadow-[var(--shadow-elegant)] ${barClasses} ${
         isTransitioning ? 'opacity-0' : 'opacity-100'
       } ${isSettingsOpen ? 'z-10' : 'z-50'}`}
     >


### PR DESCRIPTION
## Summary
- give top bar and bottom bar a translucent backdrop with borders so they stand out as "forehead" and "chin" on mobile
- keep bar colors consistent between day and night themes

## Codex CI
- `npm ci --legacy-peer-deps`
- `npm test`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869f897e7cc83339ff2fcc5a179b50c