### PR TITLE
Feature: color input and mobile tabs

### DIFF
--- a/src/components/experience/SceneSettingsPanel.tsx
+++ b/src/components/experience/SceneSettingsPanel.tsx
@@ -125,17 +125,17 @@ const SceneSettingsPanel = ({
 
       <div className="flex-1 overflow-hidden">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
-          <TabsList className={`grid w-full grid-cols-2 mx-4 mt-4 ${colors.cardBg} ${colors.border}`}>
-            <TabsTrigger 
-              value="main" 
-              className={`flex items-center gap-2 ${isMobile ? 'text-xs' : 'text-sm'} data-[state=active]:${colors.background} data-[state=active]:${colors.primaryText}`}
+          <TabsList className={`grid w-full grid-cols-2 mx-4 mt-4 ${colors.cardBg} ${colors.border} rounded-lg overflow-hidden`}>
+            <TabsTrigger
+              value="main"
+              className={`flex items-center gap-2 border-b-2 border-transparent ${isMobile ? 'text-xs' : 'text-sm'} data-[state=active]:${colors.background} data-[state=active]:${colors.primaryText} data-[state=active]:border-b-blue-500`}
             >
               <Palette className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'}`} />
               Main Object
             </TabsTrigger>
-            <TabsTrigger 
-              value="objects" 
-              className={`flex items-center gap-2 ${isMobile ? 'text-xs' : 'text-sm'} data-[state=active]:${colors.background} data-[state=active]:${colors.primaryText}`}
+            <TabsTrigger
+              value="objects"
+              className={`flex items-center gap-2 border-b-2 border-transparent ${isMobile ? 'text-xs' : 'text-sm'} data-[state=active]:${colors.background} data-[state=active]:${colors.primaryText} data-[state=active]:border-b-blue-500`}
             >
               <Shapes className={`${isMobile ? 'w-3 h-3' : 'w-4 h-4'}`} />
               Scene Objects ({objects.length})

--- a/src/components/scene/controls/MainObjectControls.tsx
+++ b/src/components/scene/controls/MainObjectControls.tsx
@@ -5,6 +5,7 @@ import { SceneConfig } from '@/types/scene';
 import { useExperience } from '@/hooks/useExperience';
 import { MaterialControlsBuilder } from './MaterialControlsBuilder';
 import { createConfigUpdater } from './ConfigUpdateUtils';
+import ColorInput from '@/components/ui/color-input';
 
 interface MainObjectControlsProps {
   sceneConfig: SceneConfig;
@@ -58,11 +59,19 @@ const MainObjectControls = ({ sceneConfig, onUpdate }: MainObjectControlsProps) 
     };
   }, [sceneConfig, onUpdate, theme, themeConfig]);
 
+  const handleColorChange = (value: string) => {
+    const update = createConfigUpdater(sceneConfig, onUpdate);
+    update(c => { c[theme].mainObjectColor = value; });
+  };
+
   return (
-    <div 
-      ref={guiContainerRef} 
-      className="w-full [&_.lil-gui]:static [&_.lil-gui]:max-w-none [&_.lil-gui]:w-full [&_.lil-gui]:bg-transparent [&_.lil-gui]:border-0 [&_.lil-gui]:shadow-none"
-    />
+    <div className="space-y-4">
+      <ColorInput label="Color" value={themeConfig.mainObjectColor} onChange={handleColorChange} />
+      <div
+        ref={guiContainerRef}
+        className="w-full [&_.lil-gui]:static [&_.lil-gui]:max-w-none [&_.lil-gui]:w-full [&_.lil-gui]:bg-transparent [&_.lil-gui]:border-0 [&_.lil-gui]:shadow-none"
+      />
+    </div>
   );
 };
 

--- a/src/components/scene/controls/components/ObjectGuiControls.tsx
+++ b/src/components/scene/controls/components/ObjectGuiControls.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import GUI from 'lil-gui';
 import { SceneObject } from '@/types/sceneObjects';
 import { useExperience } from '@/hooks/useExperience';
+import ColorInput from '@/components/ui/color-input';
 
 interface ObjectGuiControlsProps {
   object: SceneObject;
@@ -103,10 +104,13 @@ const ObjectGuiControls = ({ object, onUpdate }: ObjectGuiControlsProps) => {
   }, [object, onUpdate, theme]);
 
   return (
-    <div 
-      ref={guiContainerRef} 
-      className="w-full [&_.lil-gui]:static [&_.lil-gui]:max-w-none [&_.lil-gui]:w-full [&_.lil-gui]:bg-transparent [&_.lil-gui]:border-0 [&_.lil-gui]:shadow-none"
-    />
+    <div className="space-y-4">
+      <ColorInput label="Color" value={object.color} onChange={(value) => onUpdate({ color: value })} />
+      <div
+        ref={guiContainerRef}
+        className="w-full [&_.lil-gui]:static [&_.lil-gui]:max-w-none [&_.lil-gui]:w-full [&_.lil-gui]:bg-transparent [&_.lil-gui]:border-0 [&_.lil-gui]:shadow-none"
+      />
+    </div>
   );
 };
 

--- a/src/components/ui/color-input.tsx
+++ b/src/components/ui/color-input.tsx
@@ -1,0 +1,29 @@
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+
+interface ColorInputProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+const ColorInput = ({ label, value, onChange, className }: ColorInputProps) => {
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <Label className="text-sm" htmlFor="color-input">
+        {label}
+      </Label>
+      <input
+        id="color-input"
+        data-testid="color-input"
+        type="color"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-8 w-8 p-0 border rounded"
+      />
+    </div>
+  );
+};
+
+export default ColorInput;

--- a/src/test/components/main-object-controls-color.test.tsx
+++ b/src/test/components/main-object-controls-color.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { render } from '../test-utils';
+import MainObjectControls from '../../components/scene/controls/MainObjectControls';
+import { SceneConfig } from '@/types/scene';
+
+vi.mock('lil-gui', () => {
+  class MockGUI {
+    domElement = document.createElement('div');
+    destroy() {}
+    add() {
+      return {
+        name: () => ({ onChange: () => {} })
+      };
+    }
+    addColor() {
+      return {
+        onChange: () => {},
+        name: () => ({ onChange: () => {} })
+      };
+    }
+    addFolder() {
+      return new MockGUI();
+    }
+    open() {}
+  }
+  return { default: MockGUI };
+});
+
+vi.mock('@/hooks/useExperience', () => ({
+  useExperience: () => ({ theme: 'day' })
+}));
+
+describe('MainObjectControls color input', () => {
+  const sceneConfig: SceneConfig = {
+    type: 'TorusKnot',
+    day: { mainObjectColor: '#ffffff', material: {}, background: { type: 'void' }, lights: [] },
+    night: { mainObjectColor: '#000000', material: {}, background: { type: 'void' }, lights: [] }
+  };
+
+  it('calls onUpdate when color input changes', () => {
+    const onUpdate = vi.fn();
+    const { getByTestId } = render(
+      <MainObjectControls sceneConfig={sceneConfig} onUpdate={onUpdate} />
+    );
+    fireEvent.change(getByTestId('color-input'), { target: { value: '#654321' } });
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      day: expect.objectContaining({ mainObjectColor: '#654321' })
+    }));
+  });
+});

--- a/src/test/components/object-gui-controls-color.test.tsx
+++ b/src/test/components/object-gui-controls-color.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { render, createMockSceneObject } from '../test-utils';
+import ObjectGuiControls from '../../components/scene/controls/components/ObjectGuiControls';
+
+vi.mock('lil-gui', () => {
+  class MockGUI {
+    domElement = document.createElement('div');
+    destroy() {}
+    addColor() {
+      return {
+        onChange: () => {},
+        name: () => ({ onChange: () => {} })
+      };
+    }
+    add() {
+      return {
+        onChange: () => {},
+        name: () => ({ onChange: () => {} })
+      };
+    }
+    addFolder() {
+      return new MockGUI();
+    }
+    open() {}
+  }
+  return { default: MockGUI };
+});
+
+vi.mock('@/hooks/useExperience', () => ({
+  useExperience: () => ({ theme: 'day' })
+}));
+
+describe('ObjectGuiControls color input', () => {
+  it('calls onUpdate when color input changes', () => {
+    const object = createMockSceneObject();
+    const onUpdate = vi.fn();
+    const { getByTestId } = render(<ObjectGuiControls object={object} onUpdate={onUpdate} />);
+    fireEvent.change(getByTestId('color-input'), { target: { value: '#123456' } });
+    expect(onUpdate).toHaveBeenCalledWith({ color: '#123456' });
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `ColorInput` component
- expose color picker for main object and scene objects
- style settings tabs for better mobile feedback
- test color pickers

## Codex CI
- `npm ci --legacy-peer-deps`
- `npm run build`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6869fd3aec0083338809f00645d0eb6e